### PR TITLE
Remove unnecessary tokenizer features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.1
+
+### What's New
+
+- Removed unnecessary features for `tokenizers` crate to make cross-compilation easier (since tokenizer training helpers aren't needed).
+
 ## v0.4.0
 
 ### What's New

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-splitter"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Ben Brandt <benjamin.j.brandt@gmail.com>"]
 edition = "2021"
 description = "Split text into semantic chunks, up to a desired chunk size. Supports calculating length by characters and tokens (when used with large language models)."
@@ -24,12 +24,18 @@ itertools = "0.10.5"
 once_cell = "1.17.2"
 regex = "1.8.3"
 tiktoken-rs = { version = "0.4.2", optional = true }
-tokenizers = { version = "0.13.3", optional = true }
+tokenizers = { version = "0.13.3", default_features = false, features = [
+    "onig",
+], optional = true }
 unicode-segmentation = "1.10.1"
 
 [dev-dependencies]
 fake = "2.6.1"
 insta = { version = "1.29.0", features = ["glob", "yaml"] }
+tokenizers = { version = "0.13.3", default-features = false, features = [
+    "onig",
+    "http",
+] }
 more-asserts = "0.3.1"
 
 [features]


### PR DESCRIPTION
Many of the features in the tokenizers crate are only necessary if you are training a new tokenizer.

Removing them by default makes cross-compilation easier.