### PR TITLE
Stop producing `next_sections` if we've reached the end of the current semantic level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+**/.DS_Store


### PR DESCRIPTION
`next_sections` produces an iterator over the rest of the text at the current semantic level.

However, we want to preserve the next highest semantic level starting point as a breakpoint, and not have a chunk traverse across it.

This enforces this behavior by limiting the amount of sections that can be iterated over to be before the next level offset.