### PR TITLE
Add CustomTextSplitter for the Python package

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,16 +9,9 @@ on:
   push:
     branches:
       - main
-      - master
     tags:
-      - "python-v*"
-    paths:
-      - "bindings/python/**"
-      - ".github/workflows/python.yml"
+      - "v*"
   pull_request:
-    paths:
-      - "bindings/python/**"
-      - ".github/workflows/python.yml"
   workflow_dispatch:
 
 concurrency:
@@ -57,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -94,7 +87,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           architecture: ${{ matrix.target }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -131,7 +124,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -182,7 +175,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/python-v')"
+    if: "startsWith(github.ref, 'refs/tags/v')"
     needs: [lints, linux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.5.1
+
+### What's New
+
+- Python bindings and Rust crate now have the same version number.
+
+#### Rust
+
+- Constructors for `ChunkSize` are now public, so you can more easily create your own `ChunkSize` structs for your own custom `ChunkSizer` implementation.
+
+#### Python
+
+- New `CustomTextSplitter` that accepts a custom callback with the signature of `(str) -> int`. Allows for custom chunk sizing on the Python side.
+
 ## v0.5.0
 
 ### What's New

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-splitter"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Ben Brandt <benjamin.j.brandt@gmail.com>"]
 edition = "2021"
 description = "Split text into semantic chunks, up to a desired chunk size. Supports calculating length by characters and tokens (when used with large language models)."

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.1 and beyond
+
+See main CHANGELOG.md for the repo.
+
 ## v0.3.1
 
 Fix broken Github release

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.77"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d19de80eff169429ac1e9f48fffb163916b448a44e8e046186232046d9e1f9"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "auto_enums"
@@ -26,7 +26,7 @@ dependencies = [
  "derive_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -43,9 +43,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bit-set"
@@ -70,9 +70,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
+checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -96,34 +96,28 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.17"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "darling"
@@ -199,7 +193,7 @@ checksum = "9abcad25e9720609ccb3dcdb795d845e37d8ce34183330a9f48b03a1a71c8e21"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -232,9 +226,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -291,9 +285,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "lock_api"
@@ -329,9 +323,9 @@ checksum = "b8dd856d451cc0da70e2ef2ce95a18e39a93b7558bedf10201ad28503f918568"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
@@ -350,9 +344,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "monostate"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e404e13820ea0df0eda93aa294e0c80de76a0daa6bec590d376fbec6d7810394"
+checksum = "878c2a1f1c70e5724fa28f101ca787b6a7e8ad5c5e4ae4ca3b0fa4a419fa9075"
 dependencies = [
  "monostate-impl",
  "serde",
@@ -360,13 +354,13 @@ dependencies = [
 
 [[package]]
 name = "monostate-impl"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531c82a934da419bed3da09bd87d6e98c72f8d4aa755427b3b009c2b8b8c433c"
+checksum = "f686d68a09079e63b1d2c64aa305095887ce50565f00a922ebfaeeee0d9ba6ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -450,9 +444,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.71"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -503,7 +497,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -515,14 +509,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -652,7 +646,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semantic-text-splitter"
-version = "0.3.1"
+version = "0.5.1"
 dependencies = [
  "pyo3",
  "text-splitter",
@@ -662,29 +656,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -728,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.43"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -739,15 +733,13 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.12"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
+checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
 
 [[package]]
 name = "text-splitter"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2472fe4430d7a5dd846f6a3d480593b955c00ddf15440f1680645061b3c0a3"
+version = "0.5.1"
 dependencies = [
  "auto_enums",
  "either",
@@ -761,22 +753,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.52"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a48fd946b02c0a526b2e9481c8e2a17755e47039164a86c4070446e3a4614d"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.52"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7fbe9b594d6568a6a1443250a7e67d80b74e1e96f6d1715e1e21cc1888291d3"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -786,7 +778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40894b788eb28bbb7e36bdc8b7b1b1488b9c93fa3730f315ab965330c94c0842"
 dependencies = [
  "anyhow",
- "base64 0.21.5",
+ "base64 0.21.7",
  "bstr",
  "fancy-regex",
  "lazy_static",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-text-splitter"
-version = "0.3.1"
+version = "0.5.1"
 authors = ["Ben Brandt <benjamin.j.brandt@gmail.com>"]
 edition = "2021"
 description = "Split text into semantic chunks, up to a desired chunk size. Supports calculating length by characters and tokens (when used with large language models)."
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.20.2", features = ["abi3-py38"] }
-text-splitter = { version = "0.5.0", features = ["tiktoken-rs", "tokenizers"] }
+text-splitter = { path = "../..", features = ["tiktoken-rs", "tokenizers"] }
 tiktoken-rs = "0.5.8"
 tokenizers = { version = "0.15.0", default_features = false, features = [
     "onig",

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -17,7 +17,7 @@
 use std::str::FromStr;
 
 use pyo3::{exceptions::PyException, prelude::*};
-use text_splitter::{Characters, ChunkCapacity, TextSplitter};
+use text_splitter::{Characters, ChunkCapacity, ChunkSize, ChunkSizer, TextSplitter};
 use tiktoken_rs::{get_bpe_from_model, CoreBPE};
 use tokenizers::Tokenizer;
 
@@ -400,6 +400,126 @@ impl TiktokenTextSplitter {
     }
 }
 
+/// Newtype around a Python callback so we can `impl ChunkSizer`
+struct CustomCallback(PyObject);
+
+impl ChunkSizer for CustomCallback {
+    /// Determine the size of a given chunk to use for validation
+    fn chunk_size(&self, chunk: &str, capacity: &impl ChunkCapacity) -> ChunkSize {
+        Python::with_gil(|py| {
+            let size = self
+                .0
+                .call(py, (chunk,), None)
+                .unwrap()
+                .extract::<usize>(py)
+                .unwrap();
+
+            ChunkSize::from_size(size, capacity)
+        })
+    }
+}
+
+/**
+Text splitter based on a custom callback. Recursively splits chunks into the largest semantic units that fit within the chunk size. Also will attempt to merge neighboring chunks if they can fit within the given chunk size.
+
+### By Number of Tokens
+
+```python
+from semantic_text_splitter import CustomTextSplitter
+
+# Maximum number of tokens in a chunk
+max_tokens = 1000
+# Optionally can also have the splitter not trim whitespace for you
+splitter = CustomTextSplitter(lambda text: len(text))
+
+chunks = splitter.chunks("your document text", max_tokens)
+```
+
+### Using a Range for Chunk Capacity
+
+You also have the option of specifying your chunk capacity as a range.
+
+Once a chunk has reached a length that falls within the range it will be returned.
+
+It is always possible that a chunk may be returned that is less than the `start` value, as adding the next piece of text may have made it larger than the `end` capacity.
+
+```python
+from semantic_text_splitter import CustomTextSplitter
+
+# Optionally can also have the splitter trim whitespace for you
+splitter = CustomTextSplitter(lambda text: len(text))
+
+# Maximum number of tokens in a chunk. Will fill up the
+# chunk until it is somewhere in this range.
+chunks = splitter.chunks("your document text", chunk_capacity=(200,1000))
+```
+
+Args:
+    callback (Callable[[str], int]): A lambda or other function that can be called. It will be
+        provided a piece of text, and it should return an integer value for the size.
+    trim_chunks (bool, optional): Specify whether chunks should have whitespace trimmed from the
+        beginning and end or not. If False, joining all chunks will return the original
+        string. Defaults to True.
+ */
+#[pyclass]
+struct CustomTextSplitter {
+    splitter: TextSplitter<CustomCallback>,
+}
+
+#[pymethods]
+impl CustomTextSplitter {
+    #[new]
+    #[pyo3(signature = (callback, trim_chunks=true))]
+    fn new(callback: PyObject, trim_chunks: bool) -> Self {
+        Self {
+            splitter: TextSplitter::new(CustomCallback(callback)).with_trim_chunks(trim_chunks),
+        }
+    }
+
+    /**
+    Generate a list of chunks from a given text. Each chunk will be up to the `chunk_capacity`.
+
+    ## Method
+
+    To preserve as much semantic meaning within a chunk as possible, a recursive approach is used, starting at larger semantic units and, if that is too large, aking it up into the next largest unit. Here is an example of the steps used:
+
+    1. Split the text by a given level
+    2. For each section, does it fit within the chunk size?
+    a. Yes. Merge as many of these neighboring sections into a chunk as possible to maximize chunk length.
+    b. No. Split by the next level and repeat.
+
+    The boundaries used to split the text if using the top-level `split` method, in descending length:
+
+    1. Descending sequence length of newlines. (Newline is `\r\n`, `\n`, or `\r`) Each unique length of consecutive newline sequences is treated as its own antic level.
+    2. [Unicode Sentence Boundaries](https://www.unicode.org/reports/tr29/#Sentence_Boundaries)
+    3. [Unicode Word Boundaries](https://www.unicode.org/reports/tr29/#Word_Boundaries)
+    4. [Unicode Grapheme Cluster Boundaries](https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries)
+    5. Characters
+
+    Splitting doesn't occur below the character level, otherwise you could get partial
+    bytes of a char, which may not be a valid unicode str.
+
+    Args:
+        text (str): Text to split.
+        chunk_capacity (int | (int, int)): The capacity of characters in each chunk. If a
+            single int, then chunks will be filled up as much as possible, without going over
+            that number. If a tuple of two integers is provided, a chunk will be considered
+            "full" once it is within the two numbers (inclusive range). So it will only fill
+            up the chunk until the lower range is met.
+
+    Returns:
+        A list of strings, one for each chunk. If `trim_chunks` was specified in the text
+        splitter, then each chunk will already be trimmed as well.
+    */
+    fn chunks<'text, 'splitter: 'text>(
+        &'splitter self,
+        text: &'text str,
+        chunk_capacity: PyChunkCapacity,
+    ) -> Vec<&'text str> {
+        self.splitter.chunks(text, chunk_capacity).collect()
+    }
+}
+
 /**
 [![Licence](https://img.shields.io/crates/l/text-splitter)](https://github.com/benbrandt/text-splitter/blob/main/LICENSE.txt)
 
@@ -477,5 +597,6 @@ fn semantic_text_splitter(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<CharacterTextSplitter>()?;
     m.add_class::<HuggingFaceTextSplitter>()?;
     m.add_class::<TiktokenTextSplitter>()?;
+    m.add_class::<CustomTextSplitter>()?;
     Ok(())
 }

--- a/bindings/python/tests/test_integration.py
+++ b/bindings/python/tests/test_integration.py
@@ -3,6 +3,7 @@ from semantic_text_splitter import (
     CharacterTextSplitter,
     HuggingFaceTextSplitter,
     TiktokenTextSplitter,
+    CustomTextSplitter,
 )
 from tokenizers import Tokenizer
 
@@ -86,3 +87,9 @@ def test_tiktoken_trim():
 def test_tiktoken_model_error():
     with pytest.raises(Exception):
         TiktokenTextSplitter("random-model-name")
+
+
+def test_custom():
+    splitter = CustomTextSplitter(lambda x: len(x))
+    text = "123\n123"
+    assert splitter.chunks(text=text, chunk_capacity=3) == ["123", "123"]


### PR DESCRIPTION
Allows for custom text splitting on the Python side. It isn't as nice as implementing the trait on the Rust side, but does make it more flexible.