### PR TITLE
Add http feature for tokenziers and remove as dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
     "/tests/inputs/**",
     "/tests/tokenizers/**",
     "*.yml",
-    "*.yaml"
+    "*.yaml",
 ]
 rust-version = "1.65.0"
 
@@ -35,7 +35,10 @@ itertools = "0.12.0"
 once_cell = "1.18.0"
 regex = "1.10.2"
 tiktoken-rs = { version = "0.5.6", optional = true }
-tokenizers = { version = "0.15.0", default_features = false, features = ["onig"], optional = true }
+tokenizers = { version = "0.15.0", default_features = false, features = [
+    "onig",
+    "http",
+], optional = true }
 unicode-segmentation = "1.10.1"
 
 [dev-dependencies]
@@ -43,10 +46,6 @@ criterion = "0.5.1"
 fake = "2.9.1"
 insta = { version = "1.34.0", features = ["glob", "yaml"] }
 more-asserts = "0.3.1"
-tokenizers = { version = "0.15.0", default-features = false, features = [
-    "onig",
-    "http",
-] }
 
 [[bench]]
 name = "chunk_size"


### PR DESCRIPTION
This should fix: https://github.com/benbrandt/text-splitter/issues/89 . This is only my second Rust contrib, so please let me know if there is anything to improve. 

I added the http feature to the tokenizers dependency. I also removed tokenizers from your dev dependencies. This probably masked the problem for you and enabled the tests to pass. You'll have to run tests with `--features` for the feature dependent tests to pass:
```bash
cargo test --features "tiktoken-rs tokenizers"
```


I would have liked to add a small GH action to run the tests, as this would have caught the bug ... but I haven't done actions for Rust yet. I might check it out if I have time towards the end of the week.