### PR TITLE
Add instructions for running examples to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ let splitter = TextSplitter::new(tokenizer)
     .with_trim_chunks(true);
 
 let chunks = splitter.chunks("your document text", max_tokens);
+println!("{}", chunks.count())
 ```
 
 ### With Tiktoken Tokenizer
@@ -65,6 +66,7 @@ let splitter = TextSplitter::new(tokenizer)
     .with_trim_chunks(true);
 
 let chunks = splitter.chunks("your document text", max_tokens);
+println!("{}", chunks.count())
 ```
 
 ### Using a Range for Chunk Capacity
@@ -85,6 +87,7 @@ let max_characters = 500..2000;
 let splitter = TextSplitter::default().with_trim_chunks(true);
 
 let chunks = splitter.chunks("your document text", max_characters);
+println!("{}", chunks.count())
 ```
 
 ## Method

--- a/README.md
+++ b/README.md
@@ -32,11 +32,9 @@ println!("{}", chunks.count())
 
 ### With Huggingface Tokenizer
 
-
+Requires the `tokenizers` feature to be activated and adding `tokenizers` to dependencies. The example below, using `from_pretrained()`, also requires tokenizers `http` feature to be enabled. 
 <details>
 <summary>
-Requires the `tokenizers` feature to be activated and adding `tokenizers` to dependencies. The example below, using `from_pretrained()`, also requires tokenizers `http` feature to be enabled. 
-
 Click to show Cargo.toml.
 </summary>
 
@@ -64,10 +62,11 @@ println!("{}", chunks.count())
 ```
 
 ### With Tiktoken Tokenizer
-<details>
-<summary>
+
 Requires the `tiktoken-rs` feature to be activated and adding `tiktoken-rs` to dependencies.
 
+<details>
+<summary>
 Click to show Cargo.toml.
 </summary>
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ let chunks = splitter.chunks("your document text", max_characters);
 
 <details>
 <summary>
-Requires the `tokenizers` feature to be activated and direct declaration of the dependency. The example below, using `from_pretrained()`, also requires tokenizers's `http` feature enabled. 
+Requires the `tokenizers` feature to be activated and adding `tokenizers` to dependencies. The example below, using `from_pretrained()`, also requires tokenizers `http` feature to be enabled. 
 
 Click to show Cargo.toml.
 </summary>
@@ -65,7 +65,7 @@ println!("{}", chunks.count())
 ### With Tiktoken Tokenizer
 <details>
 <summary>
-Requires the `tiktoken-rs` feature to be activated and direct declaration of the dependency.
+Requires the `tiktoken-rs` feature to be activated and adding `tiktoken-rs` to dependencies.
 
 Click to show Cargo.toml.
 </summary>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,20 @@ let chunks = splitter.chunks("your document text", max_characters);
 
 ### With Huggingface Tokenizer
 
-Requires the `tokenizers` feature to be activated.
+
+<details>
+<summary>
+Requires the `tokenizers` feature to be activated and direct declaration of the dependency. The example below, using `from_pretrained()`, also requires tokenizers's `http` feature enabled. 
+
+Click to show Cargo.toml.
+</summary>
+
+```toml
+[dependencies]
+text-splitter = { version = "0.6", features = ["tokenizers"] }
+tokenizers = { version = "0.15", features = ["http"] }
+```
+</details>
 
 ```rust
 use text_splitter::TextSplitter;
@@ -50,8 +63,18 @@ println!("{}", chunks.count())
 ```
 
 ### With Tiktoken Tokenizer
+<details>
+<summary>
+Requires the `tiktoken-rs` feature to be activated and direct declaration of the dependency.
 
-Requires the `tiktoken-rs` feature to be activated.
+Click to show Cargo.toml.
+</summary>
+
+```toml
+text-splitter = { version = "0.6", features = ["tiktoken-rs"] }
+tiktoken-rs = "0.5"
+```
+</details>
 
 ```rust
 use text_splitter::TextSplitter;

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ let splitter = TextSplitter::default()
     .with_trim_chunks(true);
 
 let chunks = splitter.chunks("your document text", max_characters);
+println!("{}", chunks.count())
 ```
 
 ### With Huggingface Tokenizer


### PR DESCRIPTION
Hi @benbrandt,
as discussed here https://github.com/benbrandt/text-splitter/issues/89, I added instructions to the README that specify the required dependencies for running the examples.

I also added a `println!("{}", chunks.count())` to the example code. This makes it easier to verify that the example is running. We could also debug print the chunks struct but that might get huge if users modify the example with their own file.