### PR TITLE
Cleanup

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -79,6 +79,19 @@ splitter = TextSplitter.from_callback(lambda text: len(text))
 chunks = splitter.chunks("your document text", chunk_capacity=(200,1000))
 ```
 
+### Markdown
+
+All of the above examples also can also work with Markdown text. You can use the `MarkdownSplitter` in the same ways as the `TextSplitter`.
+
+```python
+from text_splitter import MarkdownSplitter
+# Default implementation uses character count for chunk size.
+# Can also use all of the same tokenizer implementations as `TextSplitter`.
+splitter = MarkdownSplitter()
+
+splitter.chunks("# Header\n\nyour document text", 1000)
+```
+
 ## Method
 
 To preserve as much semantic meaning within a chunk as possible, each chunk is composed of the largest semantic units that can fit in the next given chunk. For each splitter type, there is a defined set of semantic levels. Here is an example of the steps used:

--- a/src/characters.rs
+++ b/src/characters.rs
@@ -1,5 +1,3 @@
-use std::ops::Range;
-
 use crate::{ChunkCapacity, ChunkSize, ChunkSizer};
 
 /// Used for splitting a piece of text into chunks based on the number of
@@ -13,16 +11,11 @@ use crate::{ChunkCapacity, ChunkSize, ChunkSizer};
 #[derive(Debug)]
 pub struct Characters;
 
-impl Characters {
-    fn encoded_offsets(chunk: &str) -> impl Iterator<Item = Range<usize>> + '_ {
-        chunk.char_indices().map(|(i, c)| i..(i + c.len_utf8()))
-    }
-}
-
 impl ChunkSizer for Characters {
     /// Determine the size of a given chunk to use for validation.
     fn chunk_size(&self, chunk: &str, capacity: &impl ChunkCapacity) -> ChunkSize {
-        ChunkSize::from_offsets(Self::encoded_offsets(chunk), capacity)
+        let offsets = chunk.char_indices().map(|(i, c)| i..(i + c.len_utf8()));
+        ChunkSize::from_offsets(offsets, capacity)
     }
 }
 
@@ -32,7 +25,11 @@ mod tests {
 
     #[test]
     fn returns_offsets() {
-        let offsets = Characters::encoded_offsets("eé").collect::<Vec<_>>();
-        assert_eq!(offsets, vec![0..1, 1..3]);
+        let capacity = 10;
+        let offsets = Characters.chunk_size("eé", &capacity);
+        assert_eq!(
+            offsets,
+            ChunkSize::from_offsets([0..1, 1..3].into_iter(), &capacity)
+        );
     }
 }

--- a/src/huggingface.rs
+++ b/src/huggingface.rs
@@ -1,20 +1,6 @@
-use std::ops::Range;
-
 use tokenizers::Tokenizer;
 
 use crate::{ChunkCapacity, ChunkSize, ChunkSizer};
-
-impl ChunkSizer for Tokenizer {
-    /// Returns the number of tokens in a given text after tokenization.
-    ///
-    /// # Panics
-    ///
-    /// Will panic if you don't have a byte-level tokenizer and the splitter
-    /// encounters text it can't tokenize.
-    fn chunk_size(&self, chunk: &str, capacity: &impl ChunkCapacity) -> ChunkSize {
-        ChunkSize::from_offsets(encoded_offsets(self, chunk), capacity)
-    }
-}
 
 impl ChunkSizer for &Tokenizer {
     /// Returns the number of tokens in a given text after tokenization.
@@ -24,41 +10,43 @@ impl ChunkSizer for &Tokenizer {
     /// Will panic if you don't have a byte-level tokenizer and the splitter
     /// encounters text it can't tokenize.
     fn chunk_size(&self, chunk: &str, capacity: &impl ChunkCapacity) -> ChunkSize {
-        ChunkSize::from_offsets(encoded_offsets(self, chunk), capacity)
+        let encoding = self
+            .encode(chunk, false)
+            .expect("Unable to tokenize the following string {chunk}");
+        let mut offsets = encoding
+            .get_offsets()
+            .iter()
+            .map(|(start, end)| {
+                let end = *end + 1;
+                *start..end
+            })
+            .collect::<Vec<_>>();
+        // Sometimes the offsets are off by one because of whitespace prefixing
+        let prefixed = offsets.last().is_some_and(|r| r.end != chunk.len());
+
+        if prefixed {
+            for range in &mut offsets {
+                if range.start != 0 {
+                    range.start -= 1;
+                }
+                range.end -= 1;
+            }
+        }
+
+        ChunkSize::from_offsets(offsets.into_iter(), capacity)
     }
 }
 
-fn encoded_offsets<'text>(
-    tokenizer: &Tokenizer,
-    chunk: &'text str,
-) -> impl Iterator<Item = Range<usize>> + 'text {
-    let encoding = tokenizer
-        .encode(chunk, false)
-        .expect("Unable to tokenize the following string {chunk}");
-    let mut offsets = encoding
-        .get_offsets()
-        .iter()
-        .map(|(start, end)| {
-            let end = *end + 1;
-            *start..end
-        })
-        .collect::<Vec<_>>();
-    // Sometimes the offsets are off by one because of whitespace prefixing
-    let prefixed = offsets
-        .last()
-        .map(|r| r.end != chunk.len())
-        .unwrap_or_default();
-
-    if prefixed {
-        for range in &mut offsets {
-            if range.start != 0 {
-                range.start -= 1;
-            }
-            range.end -= 1;
-        }
+impl ChunkSizer for Tokenizer {
+    /// Returns the number of tokens in a given text after tokenization.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if you don't have a byte-level tokenizer and the splitter
+    /// encounters text it can't tokenize.
+    fn chunk_size(&self, chunk: &str, capacity: &impl ChunkCapacity) -> ChunkSize {
+        (&self).chunk_size(chunk, capacity)
     }
-
-    offsets.into_iter()
 }
 
 #[cfg(test)]
@@ -68,14 +56,23 @@ mod tests {
     #[test]
     fn returns_offsets() {
         let tokenizer = Tokenizer::from_pretrained("bert-base-cased", None).unwrap();
-        let offsets = encoded_offsets(&tokenizer, " An apple a").collect::<Vec<_>>();
-        assert_eq!(offsets, vec![0..3, 3..9, 9..11]);
+        let capacity = 10;
+        let offsets = tokenizer.chunk_size(" An apple a", &capacity);
+        assert_eq!(
+            offsets,
+            ChunkSize::from_offsets([0..3, 3..9, 9..11].into_iter(), &capacity)
+        );
     }
 
     #[test]
     fn returns_offsets_handles_prefix() {
         let tokenizer = Tokenizer::from_pretrained("bert-base-cased", None).unwrap();
-        let offsets = encoded_offsets(&tokenizer, "An apple a").collect::<Vec<_>>();
-        assert_eq!(offsets, vec![0..2, 2..8, 8..10]);
+
+        let capacity = 10;
+        let offsets = tokenizer.chunk_size("An apple a", &capacity);
+        assert_eq!(
+            offsets,
+            ChunkSize::from_offsets([0..2, 2..8, 8..10].into_iter(), &capacity)
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,9 @@
 
 use std::{
     cmp::Ordering,
-    fmt,
-    iter::once,
     ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive},
 };
 
-use either::Either;
 use itertools::Itertools;
 
 mod characters;
@@ -198,28 +195,6 @@ impl ChunkCapacity for RangeToInclusive<usize> {
     }
 }
 
-/// How a particular semantic level relates to surrounding text elements.
-#[allow(dead_code)]
-#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-enum SemanticSplitPosition {
-    /// The semantic level should be included in the previous chunk.
-    Prev,
-    /// The semantic level should be treated as its own chunk.
-    Own,
-    /// The semantic level should be included in the next chunk.
-    Next,
-}
-
-/// Information required by generic Semantic Levels
-trait Level: fmt::Debug {
-    fn split_position(&self) -> SemanticSplitPosition;
-
-    /// Whether or not when splitting ranges, whitespace should be included as previous.
-    fn treat_whitespace_as_previous(&self) -> bool {
-        false
-    }
-}
-
 /// Implementation that dictates the semantic split points available.
 /// For plain text, this goes from characters, to grapheme clusters, to words,
 /// to sentences, to linebreaks.
@@ -227,7 +202,7 @@ trait Level: fmt::Debug {
 /// lists, and code blocks.
 trait SemanticSplit {
     /// Internal type used to represent the level of semantic splitting.
-    type Level: Copy + Level + Ord + PartialOrd + 'static;
+    type Level: Copy + Ord + PartialOrd + 'static;
 
     /// Levels that are always considered in splitting text, because they are always present.
     const PERSISTENT_LEVELS: &'static [Self::Level];
@@ -522,82 +497,6 @@ where
             }
         }
     }
-}
-
-/// Given a list of separator ranges, construct the sections of the text
-fn split_str_by_separator<L: Level>(
-    text: &str,
-    separator_ranges: impl Iterator<Item = (L, Range<usize>)>,
-) -> impl Iterator<Item = (usize, &str)> {
-    let mut cursor = 0;
-    let mut final_match = false;
-    separator_ranges
-        .batching(move |it| {
-            loop {
-                match it.next() {
-                    // If we've hit the end, actually return None
-                    None if final_match => return None,
-                    // First time we hit None, return the final section of the text
-                    None => {
-                        final_match = true;
-                        return text.get(cursor..).map(|t| Either::Left(once((cursor, t))));
-                    }
-                    // Return text preceding match + the match
-                    Some((level, range)) => {
-                        let offset = cursor;
-                        match level.split_position() {
-                            SemanticSplitPosition::Prev => {
-                                if range.end < cursor {
-                                    continue;
-                                }
-                                let section = text
-                                    .get(cursor..range.end)
-                                    .expect("invalid character sequence");
-                                cursor = range.end;
-                                return Some(Either::Left(once((offset, section))));
-                            }
-                            SemanticSplitPosition::Own => {
-                                if range.start < cursor {
-                                    continue;
-                                }
-                                let prev_section = text
-                                    .get(cursor..range.start)
-                                    .expect("invalid character sequence");
-                                if prev_section.trim().is_empty()
-                                    && level.treat_whitespace_as_previous()
-                                {
-                                    let section = text
-                                        .get(cursor..range.end)
-                                        .expect("invalid character sequence");
-                                    cursor = range.end;
-                                    return Some(Either::Left(once((offset, section))));
-                                }
-                                let separator = text
-                                    .get(range.start..range.end)
-                                    .expect("invalid character sequence");
-                                cursor = range.end;
-                                return Some(Either::Right(
-                                    [(offset, prev_section), (range.start, separator)].into_iter(),
-                                ));
-                            }
-                            SemanticSplitPosition::Next => {
-                                if range.start < cursor {
-                                    continue;
-                                }
-                                let prev_section = text
-                                    .get(cursor..range.start)
-                                    .expect("invalid character sequence");
-                                // Separator will be part of the next chunk
-                                cursor = range.start;
-                                return Some(Either::Left(once((offset, prev_section))));
-                            }
-                        }
-                    }
-                }
-            }
-        })
-        .flatten()
-        .filter(|(_, s)| !s.is_empty())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
1. Simplifies the trait impls for Tokenizer implementations, allowing the by-value impl to call the reference impl
2. Once the `SemanticSplit` trait was introduced, I tried too hard to reuse the `split_by_separator` function, but there really are unique implementations between Text and Markdown here. I was overfitting structure, and I never felt quite right with the `Level` trait because it was introduced to support parameterizing this function. The compiler tried telling me this was a bad idea by the fact there was dead code if the markdown feature wasn't enabled, and I didn't listen.