### PR TITLE
Python splitters optionally provide chunk char offsets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,6 +1188,7 @@ dependencies = [
 name = "semantic-text-splitter"
 version = "0.9.0"
 dependencies = [
+ "auto_enums",
  "pyo3",
  "text-splitter",
  "tiktoken-rs",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -15,6 +15,7 @@ name = "semantic_text_splitter"
 crate-type = ["cdylib"]
 
 [dependencies]
+auto_enums = "0.8.5"
 pyo3 = { version = "0.21.1", features = ["abi3-py38"] }
 text-splitter = { path = "../..", features = [
     "markdown",

--- a/bindings/python/semantic_text_splitter.pyi
+++ b/bindings/python/semantic_text_splitter.pyi
@@ -202,6 +202,28 @@ class TextSplitter:
             splitter, then each chunk will already be trimmed as well.
         """
 
+    def chunk_indices(
+        self, text: str, chunk_capacity: Union[int, Tuple[int, int]]
+    ) -> List[Tuple[int, str]]:
+        """Generate a list of chunks from a given text, along with their character offsets in the original text. Each chunk will be up to the `chunk_capacity`.
+
+        See `chunks` for more information.
+
+        Args:
+            text (str): Text to split.
+            chunk_capacity (int | (int, int)): The capacity of characters in each chunk. If a
+                single int, then chunks will be filled up as much as possible, without going over
+                that number. If a tuple of two integers is provided, a chunk will be considered
+                "full" once it is within the two numbers (inclusive range). So it will only fill
+                up the chunk until the lower range is met.
+
+        Returns:
+            A list of tuples, one for each chunk. The first item will be the character offset relative
+            to the original text. The second item is the chunk itself.
+            If `trim_chunks` was specified in the text splitter, then each chunk will already be
+            trimmed as well.
+        """
+
 
 class MarkdownSplitter:
     """Markdown splitter. Recursively splits chunks into the largest semantic units that fit within the chunk size. Also will attempt to merge neighboring chunks if they can fit within the given chunk size.
@@ -413,4 +435,26 @@ class MarkdownSplitter:
         Returns:
             A list of strings, one for each chunk. If `trim_chunks` was specified in the text
             splitter, then each chunk will already be trimmed as well.
+        """
+
+    def chunk_indices(
+        self, text: str, chunk_capacity: Union[int, Tuple[int, int]]
+    ) -> List[Tuple[int, str]]:
+        """Generate a list of chunks from a given text, along with their character offsets in the original text. Each chunk will be up to the `chunk_capacity`.
+
+        See `chunks` for more information.
+
+        Args:
+            text (str): Text to split.
+            chunk_capacity (int | (int, int)): The capacity of characters in each chunk. If a
+                single int, then chunks will be filled up as much as possible, without going over
+                that number. If a tuple of two integers is provided, a chunk will be considered
+                "full" once it is within the two numbers (inclusive range). So it will only fill
+                up the chunk until the lower range is met.
+
+        Returns:
+            A list of tuples, one for each chunk. The first item will be the character offset relative
+            to the original text. The second item is the chunk itself.
+            If `trim_chunks` was specified in the text splitter, then each chunk will already be
+            trimmed as well.
         """

--- a/bindings/python/tests/test_integration.py
+++ b/bindings/python/tests/test_integration.py
@@ -3,13 +3,13 @@ from semantic_text_splitter import MarkdownSplitter, TextSplitter
 from tokenizers import Tokenizer
 
 
-def test_chunks():
+def test_chunks() -> None:
     splitter = TextSplitter(trim_chunks=False)
     text = "123\n123"
     assert splitter.chunks(text, 4) == ["123\n", "123"]
 
 
-def test_chunks_range():
+def test_chunks_range() -> None:
     splitter = TextSplitter(trim_chunks=False)
     text = "123\n123"
     assert splitter.chunks(text=text, chunk_capacity=(3, 4)) == [
@@ -18,41 +18,41 @@ def test_chunks_range():
     ]
 
 
-def test_chunks_trim():
+def test_chunks_trim() -> None:
     splitter = TextSplitter()
     text = "123\n123"
     assert splitter.chunks(text=text, chunk_capacity=4) == ["123", "123"]
 
 
-def test_hugging_face():
+def test_hugging_face() -> None:
     tokenizer = Tokenizer.from_pretrained("bert-base-uncased")
     splitter = TextSplitter.from_huggingface_tokenizer(tokenizer, trim_chunks=False)
     text = "123\n123"
     assert splitter.chunks(text, 1) == ["123\n", "123"]
 
 
-def test_hugging_face_range():
+def test_hugging_face_range() -> None:
     tokenizer = Tokenizer.from_pretrained("bert-base-uncased")
     splitter = TextSplitter.from_huggingface_tokenizer(tokenizer, trim_chunks=False)
     text = "123\n123"
     assert splitter.chunks(text=text, chunk_capacity=(1, 2)) == ["123\n", "123"]
 
 
-def test_hugging_face_trim():
+def test_hugging_face_trim() -> None:
     tokenizer = Tokenizer.from_pretrained("bert-base-uncased")
     splitter = TextSplitter.from_huggingface_tokenizer(tokenizer)
     text = "123\n123"
     assert splitter.chunks(text=text, chunk_capacity=1) == ["123", "123"]
 
 
-def test_hugging_face_from_str():
+def test_hugging_face_from_str() -> None:
     tokenizer = Tokenizer.from_pretrained("bert-base-uncased")
     splitter = TextSplitter.from_huggingface_tokenizer_str(tokenizer.to_str())
     text = "123\n123"
     assert splitter.chunks(text=text, chunk_capacity=1) == ["123", "123"]
 
 
-def test_hugging_face_from_file():
+def test_hugging_face_from_file() -> None:
     splitter = TextSplitter.from_huggingface_tokenizer_file(
         "tests/bert-base-cased.json"
     )
@@ -60,7 +60,7 @@ def test_hugging_face_from_file():
     assert splitter.chunks(text=text, chunk_capacity=1) == ["123", "123"]
 
 
-def test_tiktoken():
+def test_tiktoken() -> None:
     splitter = TextSplitter.from_tiktoken_model(
         model="gpt-3.5-turbo", trim_chunks=False
     )
@@ -68,7 +68,7 @@ def test_tiktoken():
     assert splitter.chunks(text, 2) == ["123\n", "123"]
 
 
-def test_tiktoken_range():
+def test_tiktoken_range() -> None:
     splitter = TextSplitter.from_tiktoken_model(
         model="gpt-3.5-turbo", trim_chunks=False
     )
@@ -79,30 +79,30 @@ def test_tiktoken_range():
     ]
 
 
-def test_tiktoken_trim():
+def test_tiktoken_trim() -> None:
     splitter = TextSplitter.from_tiktoken_model("gpt-3.5-turbo")
     text = "123\n123"
     assert splitter.chunks(text=text, chunk_capacity=1) == ["123", "123"]
 
 
-def test_tiktoken_model_error():
+def test_tiktoken_model_error() -> None:
     with pytest.raises(Exception):
         TextSplitter.from_tiktoken_model("random-model-name")
 
 
-def test_custom():
+def test_custom() -> None:
     splitter = TextSplitter.from_callback(lambda x: len(x))
     text = "123\n123"
     assert splitter.chunks(text=text, chunk_capacity=3) == ["123", "123"]
 
 
-def test_markdown_chunks():
+def test_markdown_chunks() -> None:
     splitter = MarkdownSplitter(trim_chunks=False)
     text = "123\n\n123"
     assert splitter.chunks(text, 4) == ["123\n", "\n123"]
 
 
-def test_markdown_chunks_range():
+def test_markdown_chunks_range() -> None:
     splitter = MarkdownSplitter(trim_chunks=False)
     text = "123\n\n123"
     assert splitter.chunks(text=text, chunk_capacity=(3, 4)) == [
@@ -111,41 +111,41 @@ def test_markdown_chunks_range():
     ]
 
 
-def test_markdown_chunks_trim():
+def test_markdown_chunks_trim() -> None:
     splitter = MarkdownSplitter()
     text = "123\n\n123"
     assert splitter.chunks(text=text, chunk_capacity=4) == ["123", "123"]
 
 
-def test_markdown_hugging_face():
+def test_markdown_hugging_face() -> None:
     tokenizer = Tokenizer.from_pretrained("bert-base-uncased")
     splitter = MarkdownSplitter.from_huggingface_tokenizer(tokenizer, trim_chunks=False)
     text = "123\n\n123"
     assert splitter.chunks(text, 1) == ["123\n", "\n123"]
 
 
-def test_markdown_hugging_face_range():
+def test_markdown_hugging_face_range() -> None:
     tokenizer = Tokenizer.from_pretrained("bert-base-uncased")
     splitter = MarkdownSplitter.from_huggingface_tokenizer(tokenizer, trim_chunks=False)
     text = "123\n\n123"
     assert splitter.chunks(text=text, chunk_capacity=(1, 2)) == ["123\n", "\n123"]
 
 
-def test_markdown_hugging_face_trim():
+def test_markdown_hugging_face_trim() -> None:
     tokenizer = Tokenizer.from_pretrained("bert-base-uncased")
     splitter = MarkdownSplitter.from_huggingface_tokenizer(tokenizer)
     text = "123\n\n123"
     assert splitter.chunks(text=text, chunk_capacity=1) == ["123", "123"]
 
 
-def test_markdown_hugging_face_from_str():
+def test_markdown_hugging_face_from_str() -> None:
     tokenizer = Tokenizer.from_pretrained("bert-base-uncased")
     splitter = MarkdownSplitter.from_huggingface_tokenizer_str(tokenizer.to_str())
     text = "123\n\n123"
     assert splitter.chunks(text=text, chunk_capacity=1) == ["123", "123"]
 
 
-def test_markdown_hugging_face_from_file():
+def test_markdown_hugging_face_from_file() -> None:
     splitter = MarkdownSplitter.from_huggingface_tokenizer_file(
         "tests/bert-base-cased.json"
     )
@@ -153,7 +153,7 @@ def test_markdown_hugging_face_from_file():
     assert splitter.chunks(text=text, chunk_capacity=1) == ["123", "123"]
 
 
-def test_markdown_tiktoken():
+def test_markdown_tiktoken() -> None:
     splitter = MarkdownSplitter.from_tiktoken_model(
         model="gpt-3.5-turbo", trim_chunks=False
     )
@@ -161,7 +161,7 @@ def test_markdown_tiktoken():
     assert splitter.chunks(text, 2) == ["123\n", "\n123"]
 
 
-def test_markdown_tiktoken_range():
+def test_markdown_tiktoken_range() -> None:
     splitter = MarkdownSplitter.from_tiktoken_model(
         model="gpt-3.5-turbo", trim_chunks=False
     )
@@ -172,18 +172,58 @@ def test_markdown_tiktoken_range():
     ]
 
 
-def test_markdown_tiktoken_trim():
+def test_markdown_tiktoken_trim() -> None:
     splitter = MarkdownSplitter.from_tiktoken_model("gpt-3.5-turbo")
     text = "123\n\n123"
     assert splitter.chunks(text=text, chunk_capacity=1) == ["123", "123"]
 
 
-def test_markdown_tiktoken_model_error():
+def test_markdown_tiktoken_model_error() -> None:
     with pytest.raises(Exception):
         MarkdownSplitter.from_tiktoken_model("random-model-name")
 
 
-def test_markdown_custom():
+def test_markdown_custom() -> None:
     splitter = MarkdownSplitter.from_callback(lambda x: len(x))
     text = "123\n\n123"
     assert splitter.chunks(text=text, chunk_capacity=3) == ["123", "123"]
+
+
+def test_char_indices() -> None:
+    splitter = TextSplitter()
+    text = "123\n123"
+    assert splitter.chunk_indices(text=text, chunk_capacity=4) == [
+        (0, "123"),
+        (4, "123"),
+    ]
+
+
+def test_char_indices_with_multibyte_character() -> None:
+    splitter = TextSplitter()
+    text = "12ü\n123"
+    assert len("12ü\n") == 4
+    assert splitter.chunk_indices(text=text, chunk_capacity=4) == [
+        (0, "12ü"),
+        (4, "123"),
+    ]
+
+
+def test_markdown_char_indices() -> None:
+    splitter = MarkdownSplitter()
+    text = "123\n456\n789"
+    assert splitter.chunk_indices(text=text, chunk_capacity=4) == [
+        (0, "123"),
+        (4, "456"),
+        (8, "789"),
+    ]
+
+
+def test_markdown_char_indices_with_multibyte_character() -> None:
+    splitter = MarkdownSplitter()
+    text = "12ü\n12ü\n12ü"
+    assert len("12ü\n") == 4
+    assert splitter.chunk_indices(text=text, chunk_capacity=4) == [
+        (0, "12ü"),
+        (4, "12ü"),
+        (8, "12ü"),
+    ]


### PR DESCRIPTION
It can be helpful to know where a given chunk falls within the entire text. On the Rust side, you can get the chunk along with its corresponding byte offset. But there wasn't a comparable method for the Python package.

Because Rust byte offsets aren't useful in Python, these are mapped to the corresponding character index of the beginning of the chunk. Since string indexing in Python is normally done with character indexes, this should allow for different string comparison and matching operations with this number.

 Closes #133 