### PR TITLE
Use tree-sitter 0.20.2 instead of 0.22.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,7 +2130,7 @@ dependencies = [
  "thiserror",
  "tiktoken-rs",
  "tokenizers",
- "tree-sitter",
+ "tree-sitter 0.20.10",
  "tree-sitter-rust",
  "unicode-segmentation",
 ]
@@ -2301,6 +2301,16 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
+name = "tree-sitter"
 version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df7cc499ceadd4dcdf7ec6d4cbc34ece92c3fa07821e287aedecd4416c516dca"
@@ -2316,7 +2326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "277690f420bf90741dea984f3da038ace46c4fe6047cba57a66822226cde1c93"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter 0.22.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ tiktoken-rs = { version = "0.5.9", optional = true }
 tokenizers = { version = "0.19.1", default_features = false, features = [
     "onig",
 ], optional = true }
-tree-sitter = { version = "0.22.6", optional = true }
+tree-sitter = { version = "0.20.2", optional = true }
 unicode-segmentation = "1.11.0"
 
 [dev-dependencies]

--- a/src/splitter/code.rs
+++ b/src/splitter/code.rs
@@ -69,7 +69,7 @@ where
         // Verify that this is a valid language so we can rely on that later.
         let mut parser = Parser::new();
         parser
-            .set_language(&language)
+            .set_language(language.clone())
             .map_err(CodeSplitterErrorRepr::LanguageError)?;
         Ok(Self {
             chunk_config: chunk_config.into(),
@@ -150,7 +150,7 @@ where
     fn parse(&self, text: &str) -> Vec<(Self::Level, Range<usize>)> {
         let mut parser = Parser::new();
         parser
-            .set_language(&self.language)
+            .set_language(self.language.clone())
             // We verify at initialization that the language is valid, so this should be safe.
             .expect("Error loading language");
         // The only reason the tree would be None is:
@@ -200,19 +200,13 @@ impl<'cursor> Iterator for CursorOffsets<'cursor> {
     fn next(&mut self) -> Option<Self::Item> {
         // There are children (can call this initially because we don't want the root node)
         if self.cursor.goto_first_child() {
-            return Some((
-                Depth(self.cursor.depth() as usize),
-                self.cursor.node().byte_range(),
-            ));
+            return Some((Depth(0), self.cursor.node().byte_range()));
         }
 
         loop {
             // There are sibling elements to grab
             if self.cursor.goto_next_sibling() {
-                return Some((
-                    Depth(self.cursor.depth() as usize),
-                    self.cursor.node().byte_range(),
-                ));
+                return Some((Depth(0), self.cursor.node().byte_range()));
             // Start going back up the tree and check for next sibling on next iteration.
             } else if self.cursor.goto_parent() {
                 continue;


### PR DESCRIPTION
Rationale: This is being used for https://github.com/TabbyML/tabby. We have a list of supportive languages, for which we are using many different `tree-sitter-<language>` crates. The underlying `tree-sitter` version we are depending on is `0.20.2`, and some of the language crates we depend on do not support `0.22.6`. For example, `tree-sitter-java` supports up to `0.21.*`.