### PR TITLE
Prep CodeSplitter Python bindings and release

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           set -e
           pip install --no-index --find-links dist --force-reinstall semantic-text-splitter
-          pip install pytest tokenizers
+          pip install pytest tokenizers tree-sitter tree-sitter-python@git+https://github.com/tree-sitter/tree-sitter-python
           pytest
 
   linux:
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -e
           pip install --no-index --find-links dist --force-reinstall semantic-text-splitter
-          pip install pytest tokenizers
+          pip install pytest tokenizers tree-sitter tree-sitter-python@git+https://github.com/tree-sitter/tree-sitter-python
           pytest
 
   windows:
@@ -130,7 +130,7 @@ jobs:
         run: |
           set -e
           pip install --no-index --find-links dist --force-reinstall semantic-text-splitter
-          pip install pytest tokenizers
+          pip install pytest tokenizers tree-sitter tree-sitter-python@git+https://github.com/tree-sitter/tree-sitter-python
           pytest
 
   macos:
@@ -166,7 +166,7 @@ jobs:
         run: |
           set -e
           pip install --no-index --find-links dist --force-reinstall semantic-text-splitter
-          pip install pytest tokenizers
+          pip install pytest tokenizers tree-sitter tree-sitter-python@git+https://github.com/tree-sitter/tree-sitter-python
           pytest
 
   sdist:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## v0.13.2
+
+### What's New
+
+New `CodeSplitter` for splitting code in any languages that [tree-sitter grammars](https://tree-sitter.github.io/tree-sitter/#parsers) are available for. It should provide decent chunks, but please provide feedback if you notice any strange behavior.
+
+#### Rust Usage
+
+```sh
+cargo add text-splitter --features code
+cargo add tree-sitter-<language>
+```
+
+```rust
+use text_splitter::CodeSplitter;
+// Default implementation uses character count for chunk size.
+// Can also use all of the same tokenizer implementations as `TextSplitter`.
+let splitter = CodeSplitter::new(tree_sitter_rust::language(), 1000).expect("Invalid tree-sitter language");
+
+let chunks = splitter.chunks("your code file");
+```
+
+#### Python Usage
+
+```python
+from semantic_text_splitter import CodeSplitter
+import tree_sitter_python
+
+# Default implementation uses character count for chunk size.
+# Can also use all of the same tokenizer implementations as `TextSplitter`.
+splitter = CodeSplitter(tree_sitter_python.language(), capacity=1000)
+
+chunks = splitter.chunks("your code file");
+```
+
 ## v0.13.1
 
 Fix a bug in the fallback logic to make sure we are still respecting the maximum bytes we should be searching in. Again, this only affects Markdown splitting at very small sizes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "semantic-text-splitter"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "auto_enums",
  "pyo3",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "text-splitter"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "ahash",
  "auto_enums",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ dependencies = [
  "text-splitter",
  "tiktoken-rs",
  "tokenizers",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["bindings/*"]
 
 [workspace.package]
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ben Brandt <benjamin.j.brandt@gmail.com>"]
 edition = "2021"
 description = "Split text into semantic chunks, up to a desired chunk size. Supports calculating length by characters and tokens, and is callable from Rust and Python."

--- a/README.md
+++ b/README.md
@@ -118,6 +118,26 @@ let splitter = MarkdownSplitter::new(max_characters);
 let chunks = splitter.chunks("# Header\n\nyour document text");
 ```
 
+### Code
+
+All of the above examples also can also work with code that can be [parsed with tree-sitter](https://tree-sitter.github.io/tree-sitter/#parsers). If you enable the `code` feature, you can use the `CodeSplitter` in the same ways as the `TextSplitter`.
+
+```sh
+cargo add text-splitter --features code
+cargo add tree-sitter-<language>
+```
+
+```rust
+use text_splitter::CodeSplitter;
+// Maximum number of characters in a chunk. Can also use a range.
+let max_characters = 1000;
+// Default implementation uses character count for chunk size.
+// Can also use all of the same tokenizer implementations as `TextSplitter`.
+let splitter = CodeSplitter::new(tree_sitter_rust::language(), max_characters).expect("Invalid tree-sitter language");
+
+let chunks = splitter.chunks("your code file");
+```
+
 ## Method
 
 To preserve as much semantic meaning within a chunk as possible, each chunk is composed of the largest semantic units that can fit in the next given chunk. For each splitter type, there is a defined set of semantic levels. Here is an example of the steps used:
@@ -154,6 +174,16 @@ Markdown is parsed according to the CommonMark spec, along with some optional fe
 
 Splitting doesn't occur below the character level, otherwise you could get partial bytes of a char, which may not be a valid unicode str.
 
+### `CodeSplitter` Semantic Levels
+
+1. Characters
+2. [Unicode Grapheme Cluster Boundaries](https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries)
+3. [Unicode Word Boundaries](https://www.unicode.org/reports/tr29/#Word_Boundaries)
+4. [Unicode Sentence Boundaries](https://www.unicode.org/reports/tr29/#Sentence_Boundaries)
+5. Ascending depth of the syntax tree. So function would have a higher level than a statement inside of the function, and so on.
+
+Splitting doesn't occur below the character level, otherwise you could get partial bytes of a char, which may not be a valid unicode str.
+
 ### Note on sentences
 
 There are lots of methods of determining sentence breaks, all to varying degrees of accuracy, and many requiring ML models to do so. Rather than trying to find the perfect sentence breaks, we rely on unicode method of sentence boundaries, which in most cases is good enough for finding a decent semantic breaking point if a paragraph is too large, and avoids the performance penalties of many other methods.
@@ -164,6 +194,7 @@ There are lots of methods of determining sentence breaks, all to varying degrees
 
 | Feature    | Description                                                                                   |
 | ---------- | --------------------------------------------------------------------------------------------- |
+| `code`     | Enables the `CodeSplitter` struct for parsing code documents via [tree-sitter parsers](https://tree-sitter.github.io/tree-sitter/#parsers). |
 | `markdown` | Enables the `MarkdownSplitter` struct for parsing Markdown documents via the CommonMark spec. |
 
 ### Tokenizer Support

--- a/benches/chunk_size.rs
+++ b/benches/chunk_size.rs
@@ -181,7 +181,7 @@ mod code {
     use std::fs;
 
     use divan::{black_box_drop, counter::BytesCount, Bencher};
-    use text_splitter::{ChunkConfig, ChunkSizer, ExperimentalCodeSplitter};
+    use text_splitter::{ChunkConfig, ChunkSizer, CodeSplitter};
 
     use crate::CHUNK_SIZES;
 
@@ -189,7 +189,7 @@ mod code {
 
     fn bench<S, G>(bencher: Bencher<'_, '_>, filename: &str, gen_splitter: G)
     where
-        G: Fn() -> ExperimentalCodeSplitter<S> + Sync,
+        G: Fn() -> CodeSplitter<S> + Sync,
         S: ChunkSizer,
     {
         bencher
@@ -208,7 +208,7 @@ mod code {
     #[divan::bench(args = CODE_FILENAMES, consts = CHUNK_SIZES)]
     fn characters<const N: usize>(bencher: Bencher<'_, '_>, filename: &str) {
         bench(bencher, filename, || {
-            ExperimentalCodeSplitter::new(tree_sitter_rust::language(), N).unwrap()
+            CodeSplitter::new(tree_sitter_rust::language(), N).unwrap()
         });
     }
 
@@ -216,7 +216,7 @@ mod code {
     #[divan::bench(args = CODE_FILENAMES, consts = CHUNK_SIZES)]
     fn tiktoken<const N: usize>(bencher: Bencher<'_, '_>, filename: &str) {
         bench(bencher, filename, || {
-            ExperimentalCodeSplitter::new(
+            CodeSplitter::new(
                 tree_sitter_rust::language(),
                 ChunkConfig::new(N).with_sizer(tiktoken_rs::cl100k_base().unwrap()),
             )
@@ -228,7 +228,7 @@ mod code {
     #[divan::bench(args = CODE_FILENAMES, consts = CHUNK_SIZES)]
     fn tokenizers<const N: usize>(bencher: Bencher<'_, '_>, filename: &str) {
         bench(bencher, filename, || {
-            ExperimentalCodeSplitter::new(
+            CodeSplitter::new(
                 tree_sitter_rust::language(),
                 ChunkConfig::new(N).with_sizer(
                     tokenizers::Tokenizer::from_pretrained("bert-base-cased", None).unwrap(),
@@ -246,7 +246,7 @@ mod code {
             let vocab_path = download_file_to_cache(
                 "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-uncased-vocab.txt",
             );
-            ExperimentalCodeSplitter::new(
+            CodeSplitter::new(
                 tree_sitter_rust::language(),
                 ChunkConfig::new(N).with_sizer(
                     rust_tokenizers::tokenizer::BertTokenizer::from_file(vocab_path, false, false)

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib"]
 auto_enums = "0.8.5"
 pyo3 = { version = "0.21.2", features = ["abi3-py38"] }
 text-splitter = { path = "../..", features = [
+    "code",
     "markdown",
     "tiktoken-rs",
     "tokenizers",
@@ -26,6 +27,7 @@ tiktoken-rs = "0.5.9"
 tokenizers = { version = "0.19.1", default_features = false, features = [
     "onig",
 ] }
+tree-sitter = "0.22.6"
 
 [lints]
 workspace = true

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -12,7 +12,13 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "black", "tokenizers"]
+test = [
+    "pytest",
+    "black",
+    "tokenizers",
+    "tree-sitter",
+    "tree-sitter-python@git+https://github.com/tree-sitter/tree-sitter-python",
+]
 docs = ["pdoc"]
 
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
 test = [
     "pytest",
     "black",
+    "mypy",
     "tokenizers",
     "tree-sitter",
     "tree-sitter-python@git+https://github.com/tree-sitter/tree-sitter-python",

--- a/bindings/python/semantic_text_splitter.pyi
+++ b/bindings/python/semantic_text_splitter.pyi
@@ -227,7 +227,7 @@ class TextSplitter:
         """
 
     def chunks(self, text: str) -> List[str]:
-        """Generate a list of chunks from a given text. Each chunk will be up to the `chunk_capacity`.
+        """Generate a list of chunks from a given text. Each chunk will be up to the `capacity`.
 
 
         ## Method
@@ -257,7 +257,7 @@ class TextSplitter:
         """
 
     def chunk_indices(self, text: str) -> List[Tuple[int, str]]:
-        """Generate a list of chunks from a given text, along with their character offsets in the original text. Each chunk will be up to the `chunk_capacity`.
+        """Generate a list of chunks from a given text, along with their character offsets in the original text. Each chunk will be up to the `capacity`.
 
         See `chunks` for more information.
 
@@ -500,7 +500,7 @@ class MarkdownSplitter:
         """
 
     def chunks(self, text: str) -> List[str]:
-        """Generate a list of chunks from a given text. Each chunk will be up to the `chunk_capacity`.
+        """Generate a list of chunks from a given text. Each chunk will be up to the `capacity`.
 
         ## Method
 
@@ -528,12 +528,12 @@ class MarkdownSplitter:
             text (str): Text to split.
 
         Returns:
-            A list of strings, one for each chunk. If `trim_chunks` was specified in the text
+            A list of strings, one for each chunk. If `trim` was specified in the text
             splitter, then each chunk will already be trimmed as well.
         """
 
     def chunk_indices(self, text: str) -> List[Tuple[int, str]]:
-        """Generate a list of chunks from a given text, along with their character offsets in the original text. Each chunk will be up to the `chunk_capacity`.
+        """Generate a list of chunks from a given text, along with their character offsets in the original text. Each chunk will be up to the `capacity`.
 
         See `chunks` for more information.
 
@@ -543,6 +543,307 @@ class MarkdownSplitter:
         Returns:
             A list of tuples, one for each chunk. The first item will be the character offset relative
             to the original text. The second item is the chunk itself.
-            If `trim_chunks` was specified in the text splitter, then each chunk will already be
+            If `trim` was specified in the text splitter, then each chunk will already be
+            trimmed as well.
+        """
+
+
+@final
+class CodeSplitter:
+    """Code splitter. Recursively splits chunks into the largest semantic units that fit within the chunk size. Also will attempt to merge neighboring chunks if they can fit within the given chunk size.
+
+    Uses [tree-sitter grammars](https://tree-sitter.github.io/tree-sitter/#parsers) for parsing the code.
+
+    ### By Number of Characters
+
+    ```python
+    from semantic_text_splitter import CodeSplitter
+    # Import the tree-sitter grammar you want to use
+    import tree_sitter_python
+
+    # Maximum number of characters in a chunk
+    max_characters = 1000
+    splitter = CodeSplitter(tree_sitter_python.language(), max_characters)
+
+    chunks = splitter.chunks("# Header\n\nyour document text")
+    ```
+
+    ### Using a Range for Chunk Capacity
+
+    You also have the option of specifying your chunk capacity as a range.
+
+    Once a chunk has reached a length that falls within the range it will be returned.
+
+    It is always possible that a chunk may be returned that is less than the `start` value, as adding the next piece of text may have made it larger than the `end` capacity.
+
+    ```python
+    from semantic_text_splitter import CodeSplitter
+    # Import the tree-sitter grammar you want to use
+    import tree_sitter_python
+
+    splitter = CodeSplitter(tree_sitter_python.language(), (200,1000))
+
+    # Maximum number of characters in a chunk. Will fill up the
+    # chunk until it is somewhere in this range.
+    chunks = splitter.chunks("# Header\n\nyour document text")
+    ```
+
+    ### Using a Hugging Face Tokenizer
+
+    ```python
+    from semantic_text_splitter import CodeSplitter
+    from tokenizers import Tokenizer
+    # Import the tree-sitter grammar you want to use
+    import tree_sitter_python
+
+    # Maximum number of tokens in a chunk
+    max_tokens = 1000
+    tokenizer = Tokenizer.from_pretrained("bert-base-uncased")
+    splitter = CodeSplitter.from_huggingface_tokenizer(tree_sitter_python.language(), tokenizer, max_tokens)
+
+    chunks = splitter.chunks("# Header\n\nyour document text")
+    ```
+
+    ### Using a Tiktoken Tokenizer
+
+
+    ```python
+    from semantic_text_splitter import CodeSplitter
+    # Import the tree-sitter grammar you want to use
+    import tree_sitter_python
+
+    # Maximum number of tokens in a chunk
+    max_tokens = 1000
+    splitter = CodeSplitter.from_tiktoken_model(tree_sitter_python.language(), "gpt-3.5-turbo", max_tokens)
+
+    chunks = splitter.chunks("# Header\n\nyour document text")
+    ```
+
+    ### Using a Custom Callback
+
+    ```python
+    from semantic_text_splitter import CodeSplitter
+    # Import the tree-sitter grammar you want to use
+    import tree_sitter_python
+
+    # Optionally can also have the splitter trim whitespace for you
+    splitter = CodeSplitter.from_callback(tree_sitter_python.language(), lambda text: len(text), (200,1000))
+
+    # Maximum number of tokens in a chunk. Will fill up the
+    # chunk until it is somewhere in this range.
+    chunks = splitter.chunks("# Header\n\nyour document text")
+    ```
+
+    Args:
+        language (int): The [tree-sitter language](https://tree-sitter.github.io/tree-sitter/#parsers)
+            to use for parsing the code.
+        capacity (int | (int, int)): The capacity of characters in each chunk. If a
+            single int, then chunks will be filled up as much as possible, without going over
+            that number. If a tuple of two integers is provided, a chunk will be considered
+            "full" once it is within the two numbers (inclusive range). So it will only fill
+            up the chunk until the lower range is met.
+        overlap (int, optional): The maximum number of allowed characters to overlap between chunks.
+            Defaults to 0.
+        trim (bool, optional): Specify whether chunks should have whitespace trimmed from the
+            beginning and end or not. If False, joining all chunks will return the original
+            string. Defaults to True.
+    """
+
+    def __init__(
+        self,
+        language: int,
+        capacity: Union[int, Tuple[int, int]],
+        overlap: int = 0,
+        trim: bool = True,
+    ) -> None: ...
+
+    @staticmethod
+    def from_huggingface_tokenizer(
+        language: int,
+        tokenizer,
+        capacity: Union[int, Tuple[int, int]],
+        overlap: int = 0,
+        trim: bool = True,
+    ) -> MarkdownSplitter:
+        """Instantiate a new code splitter from a Hugging Face Tokenizer instance.
+
+        Args:
+            language (int): The [tree-sitter language](https://tree-sitter.github.io/tree-sitter/#parsers)
+                to use for parsing the code.
+            tokenizer (Tokenizer): A `tokenizers.Tokenizer` you want to use to count tokens for each
+                chunk.
+            capacity (int | (int, int)): The capacity of tokens in each chunk. If a
+                single int, then chunks will be filled up as much as possible, without going over
+                that number. If a tuple of two integers is provided, a chunk will be considered
+                "full" once it is within the two numbers (inclusive range). So it will only fill
+                up the chunk until the lower range is met.
+            overlap (int, optional): The maximum number of allowed tokens to overlap between chunks.
+                Defaults to 0.
+            trim (bool, optional): Specify whether chunks should have whitespace trimmed from the
+                beginning and end or not. If False, joining all chunks will return the original
+                string. Defaults to True.
+
+        Returns:
+            The new code splitter
+        """
+
+    @staticmethod
+    def from_huggingface_tokenizer_str(
+        language: int,
+        json: str,
+        capacity: Union[int, Tuple[int, int]],
+        overlap: int = 0,
+        trim: bool = True,
+    ) -> MarkdownSplitter:
+        """Instantiate a new code splitter from the given Hugging Face Tokenizer JSON string.
+
+        Args:
+            language (int): The [tree-sitter language](https://tree-sitter.github.io/tree-sitter/#parsers)
+                to use for parsing the code.
+            json (str): A valid JSON string representing a previously serialized
+                Hugging Face Tokenizer
+            capacity (int | (int, int)): The capacity of tokens in each chunk. If a
+                single int, then chunks will be filled up as much as possible, without going over
+                that number. If a tuple of two integers is provided, a chunk will be considered
+                "full" once it is within the two numbers (inclusive range). So it will only fill
+                up the chunk until the lower range is met.
+            overlap (int, optional): The maximum number of allowed tokens to overlap between chunks.
+                Defaults to 0.
+            trim (bool, optional): Specify whether chunks should have whitespace trimmed from the
+                beginning and end or not. If False, joining all chunks will return the original
+                string. Defaults to True.
+
+        Returns:
+            The new code splitter
+        """
+
+    @staticmethod
+    def from_huggingface_tokenizer_file(
+        language: int,
+        path: str,
+        capacity: Union[int, Tuple[int, int]],
+        overlap: int = 0,
+        trim: bool = True,
+    ) -> MarkdownSplitter:
+        """Instantiate a new code splitter from the Hugging Face tokenizer file at the given path.
+
+        Args:
+            language (int): The [tree-sitter language](https://tree-sitter.github.io/tree-sitter/#parsers)
+                to use for parsing the code.
+            path (str): A path to a local JSON file representing a previously serialized
+                Hugging Face tokenizer.
+            capacity (int | (int, int)): The capacity of tokens in each chunk. If a
+                single int, then chunks will be filled up as much as possible, without going over
+                that number. If a tuple of two integers is provided, a chunk will be considered
+                "full" once it is within the two numbers (inclusive range). So it will only fill
+                up the chunk until the lower range is met.
+            overlap (int, optional): The maximum number of allowed tokens to overlap between chunks.
+                Defaults to 0.
+            trim (bool, optional): Specify whether chunks should have whitespace trimmed from the
+                beginning and end or not. If False, joining all chunks will return the original
+                string. Defaults to True.
+
+        Returns:
+            The new code splitter
+        """
+
+    @staticmethod
+    def from_tiktoken_model(
+        language: int,
+        model: str,
+        capacity: Union[int, Tuple[int, int]],
+        overlap: int = 0,
+        trim: bool = True,
+    ) -> MarkdownSplitter:
+        """Instantiate a new code splitter based on an OpenAI Tiktoken tokenizer.
+
+        Args:
+            language (int): The [tree-sitter language](https://tree-sitter.github.io/tree-sitter/#parsers)
+                to use for parsing the code.
+            model (str): The OpenAI model name you want to retrieve a tokenizer for.
+            capacity (int | (int, int)): The capacity of tokens in each chunk. If a
+                single int, then chunks will be filled up as much as possible, without going over
+                that number. If a tuple of two integers is provided, a chunk will be considered
+                "full" once it is within the two numbers (inclusive range). So it will only fill
+                up the chunk until the lower range is met.
+            overlap (int, optional): The maximum number of allowed tokens to overlap between chunks.
+                Defaults to 0.
+            trim (bool, optional): Specify whether chunks should have whitespace trimmed from the
+                beginning and end or not. If False, joining all chunks will return the original
+                string. Defaults to True.
+
+        Returns:
+            The new code splitter
+        """
+
+    @staticmethod
+    def from_callback(
+        language: int,
+        callback: Callable[[str], int],
+        capacity: Union[int, Tuple[int, int]],
+        overlap: int = 0,
+        trim: bool = True,
+    ) -> MarkdownSplitter:
+        """Instantiate a code text splitter based on a custom callback.
+
+        Args:
+            language (int): The [tree-sitter language](https://tree-sitter.github.io/tree-sitter/#parsers)
+                to use for parsing the code.
+            callback (Callable[[str], int]): A lambda or other function that can be called. It will be
+                provided a piece of text, and it should return an integer value for the size.
+            capacity (int | (int, int)): The capacity of each chunk. If a
+                single int, then chunks will be filled up as much as possible, without going over
+                that number. If a tuple of two integers is provided, a chunk will be considered
+                "full" once it is within the two numbers (inclusive range). So it will only fill
+                up the chunk until the lower range is met.
+            overlap (int, optional): The maximum allowed overlap to overlap between chunks.
+                Defaults to 0.
+            trim (bool, optional): Specify whether chunks should have whitespace trimmed from the
+                beginning and end or not. If False, joining all chunks will return the original
+                string. Defaults to True.
+
+        Returns:
+            The new code splitter
+        """
+
+    def chunks(self, text: str) -> List[str]:
+        """Generate a list of chunks from a given text. Each chunk will be up to the `capacity`.
+
+        ## Method
+
+        To preserve as much semantic meaning within a chunk as possible, each chunk is composed of the largest semantic units that can fit in the next given chunk. For each splitter type, there is a defined set of semantic levels. Here is an example of the steps used:
+
+        1. Split the text by a increasing semantic levels.
+        2. Check the first item for each level and select the highest level whose first item still fits within the chunk size.
+        3. Merge as many of these neighboring sections of this level or above into a chunk to maximize chunk length. Boundaries of higher semantic levels are always included when merging, so that the chunk doesn't inadvertantly cross semantic boundaries.
+
+        The boundaries used to split the text if using the `chunks` method, in ascending order:
+
+        1. Characters
+        2. [Unicode Grapheme Cluster Boundaries](https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries)
+        3. [Unicode Word Boundaries](https://www.unicode.org/reports/tr29/#Word_Boundaries)
+        4. [Unicode Sentence Boundaries](https://www.unicode.org/reports/tr29/#Sentence_Boundaries)
+        5. Ascending depth of the syntax tree. So function would have a higher level than a statement inside of the function, and so on.
+
+        Args:
+            text (str): Text to split.
+
+        Returns:
+            A list of strings, one for each chunk. If `trim` was specified in the text
+            splitter, then each chunk will already be trimmed as well.
+        """
+
+    def chunk_indices(self, text: str) -> List[Tuple[int, str]]:
+        """Generate a list of chunks from a given text, along with their character offsets in the original text. Each chunk will be up to the `capacity`.
+
+        See `chunks` for more information.
+
+        Args:
+            text (str): Text to split.
+
+        Returns:
+            A list of tuples, one for each chunk. The first item will be the character offset relative
+            to the original text. The second item is the chunk itself.
+            If `trim` was specified in the text splitter, then each chunk will already be
             trimmed as well.
         """

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -8,15 +8,17 @@ use std::str::FromStr;
 use auto_enums::auto_enum;
 use pyo3::{
     exceptions::{PyException, PyValueError},
+    ffi,
     prelude::*,
     pybacked::PyBackedStr,
 };
 use text_splitter::{
     Characters, ChunkCapacity, ChunkCapacityError, ChunkConfig, ChunkConfigError, ChunkSize,
-    ChunkSizer, MarkdownSplitter, TextSplitter,
+    ChunkSizer, CodeSplitter, CodeSplitterError, MarkdownSplitter, TextSplitter,
 };
 use tiktoken_rs::{get_bpe_from_model, CoreBPE};
 use tokenizers::Tokenizer;
+use tree_sitter::{ffi::TSLanguage, Language};
 
 /// Custom chunk capacity for python to make it easier to work
 /// with python arguments
@@ -63,6 +65,20 @@ impl From<ChunkConfigError> for PyChunkConfigError {
 
 impl From<PyChunkConfigError> for PyErr {
     fn from(err: PyChunkConfigError) -> Self {
+        PyValueError::new_err(err.0.to_string())
+    }
+}
+
+struct PyCodeSplitterError(CodeSplitterError);
+
+impl From<CodeSplitterError> for PyCodeSplitterError {
+    fn from(err: CodeSplitterError) -> Self {
+        Self(err)
+    }
+}
+
+impl From<PyCodeSplitterError> for PyErr {
+    fn from(err: PyCodeSplitterError) -> Self {
         PyValueError::new_err(err.0.to_string())
     }
 }
@@ -935,10 +951,465 @@ impl PyMarkdownSplitter {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
+enum CodeSplitterOptions {
+    Characters(CodeSplitter<Characters>),
+    CustomCallback(CodeSplitter<CustomCallback>),
+    Huggingface(CodeSplitter<Tokenizer>),
+    Tiktoken(CodeSplitter<CoreBPE>),
+}
+
+impl CodeSplitterOptions {
+    #[auto_enum(Iterator)]
+    fn chunks<'splitter, 'text: 'splitter>(
+        &'splitter self,
+        text: &'text str,
+    ) -> impl Iterator<Item = &'text str> + 'splitter {
+        match self {
+            Self::Characters(splitter) => splitter.chunks(text),
+            Self::CustomCallback(splitter) => splitter.chunks(text),
+            Self::Huggingface(splitter) => splitter.chunks(text),
+            Self::Tiktoken(splitter) => splitter.chunks(text),
+        }
+    }
+
+    #[auto_enum(Iterator)]
+    fn chunk_indices<'splitter, 'text: 'splitter>(
+        &'splitter self,
+        text: &'text str,
+    ) -> impl Iterator<Item = (usize, &'text str)> + 'splitter {
+        match self {
+            Self::Characters(splitter) => splitter.chunk_indices(text),
+            Self::CustomCallback(splitter) => splitter.chunk_indices(text),
+            Self::Huggingface(splitter) => splitter.chunk_indices(text),
+            Self::Tiktoken(splitter) => splitter.chunk_indices(text),
+        }
+    }
+}
+
+/**
+Code splitter. Recursively splits chunks into the largest semantic units that fit within the chunk size. Also will attempt to merge neighboring chunks if they can fit within the given chunk size.
+
+### By Number of Characters
+
+```python
+from semantic_text_splitter import CodeSplitter
+
+# Maximum number of characters in a chunk
+max_characters = 1000
+# Optionally can also have the splitter not trim whitespace for you
+splitter = CodeSplitter()
+# splitter = CodeSplitter(trim_chunks=False)
+
+chunks = splitter.chunks("# Header\n\nyour document text", max_characters)
+```
+
+### Using a Range for Chunk Capacity
+
+You also have the option of specifying your chunk capacity as a range.
+
+Once a chunk has reached a length that falls within the range it will be returned.
+
+It is always possible that a chunk may be returned that is less than the `start` value, as adding the next piece of text may have made it larger than the `end` capacity.
+
+```python
+from semantic_text_splitter import CodeSplitter
+
+splitter = CodeSplitter()
+
+# Maximum number of characters in a chunk. Will fill up the
+# chunk until it is somewhere in this range.
+chunks = splitter.chunks("# Header\n\nyour document text", chunk_capacity=(200,1000))
+```
+
+### Using a Hugging Face Tokenizer
+
+```python
+from semantic_text_splitter import CodeSplitter
+from tokenizers import Tokenizer
+
+# Maximum number of tokens in a chunk
+max_tokens = 1000
+tokenizer = Tokenizer.from_pretrained("bert-base-uncased")
+splitter = CodeSplitter.from_huggingface_tokenizer(tokenizer)
+
+chunks = splitter.chunks("# Header\n\nyour document text", max_tokens)
+```
+
+### Using a Tiktoken Tokenizer
+
+
+```python
+from semantic_text_splitter import CodeSplitter
+
+# Maximum number of tokens in a chunk
+max_tokens = 1000
+splitter = CodeSplitter.from_tiktoken_model("gpt-3.5-turbo")
+
+chunks = splitter.chunks("# Header\n\nyour document text", max_tokens)
+```
+
+### Using a Custom Callback
+
+```python
+from semantic_text_splitter import CodeSplitter
+
+# Optionally can also have the splitter trim whitespace for you
+splitter = CodeSplitter.from_callback(lambda text: len(text))
+
+# Maximum number of tokens in a chunk. Will fill up the
+# chunk until it is somewhere in this range.
+chunks = splitter.chunks("# Header\n\nyour document text", chunk_capacity=(200,1000))
+```
+
+Args:
+    capacity (int | (int, int)): The capacity of characters in each chunk. If a
+        single int, then chunks will be filled up as much as possible, without going over
+        that number. If a tuple of two integers is provided, a chunk will be considered
+        "full" once it is within the two numbers (inclusive range). So it will only fill
+        up the chunk until the lower range is met.
+    overlap (int, optional): The maximum number of allowed characters to overlap between chunks.
+        Defaults to 0.
+    trim (bool, optional): Specify whether chunks should have whitespace trimmed from the
+        beginning and end or not. If False, joining all chunks will return the original
+        string. Defaults to True.
+*/
+#[pyclass(frozen, name = "CodeSplitter")]
+struct PyCodeSplitter {
+    splitter: CodeSplitterOptions,
+}
+
+impl PyCodeSplitter {
+    /// Converts the output of a Python tree-sitter language object into a `Language` struct.
+    fn load_language(language: &Bound<'_, PyAny>) -> Language {
+        unsafe { Language::from_raw(ffi::PyLong_AsVoidPtr(language.as_ptr()) as *const TSLanguage) }
+    }
+}
+
+#[pymethods]
+impl PyCodeSplitter {
+    #[new]
+    #[pyo3(signature = (language, capacity, overlap=0, trim=true))]
+    fn new(
+        language: &Bound<'_, PyAny>,
+        capacity: PyChunkCapacity,
+        overlap: usize,
+        trim: bool,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            splitter: CodeSplitterOptions::Characters(
+                CodeSplitter::new(
+                    Self::load_language(language),
+                    ChunkConfig::new(ChunkCapacity::try_from(capacity)?)
+                        .with_overlap(overlap)
+                        .map_err(PyChunkConfigError)?
+                        .with_trim(trim),
+                )
+                .map_err(PyCodeSplitterError)?,
+            ),
+        })
+    }
+
+    /**
+    Instantiate a new markdown splitter from a Hugging Face Tokenizer instance.
+
+    Args:
+        tokenizer (Tokenizer): A `tokenizers.Tokenizer` you want to use to count tokens for each
+            chunk.
+        capacity (int | (int, int)): The capacity of tokens in each chunk. If a
+            single int, then chunks will be filled up as much as possible, without going over
+            that number. If a tuple of two integers is provided, a chunk will be considered
+            "full" once it is within the two numbers (inclusive range). So it will only fill
+            up the chunk until the lower range is met.
+        overlap (int, optional): The maximum number of allowed tokens to overlap between chunks.
+            Defaults to 0.
+        trim (bool, optional): Specify whether chunks should have whitespace trimmed from the
+            beginning and end or not. If False, joining all chunks will return the original
+            string. Defaults to True.
+
+    Returns:
+        The new markdown splitter
+    */
+    #[staticmethod]
+    #[pyo3(signature = (language, tokenizer, capacity, overlap=0, trim=true))]
+    fn from_huggingface_tokenizer(
+        language: &Bound<'_, PyAny>,
+        tokenizer: &Bound<'_, PyAny>,
+        capacity: PyChunkCapacity,
+        overlap: usize,
+        trim: bool,
+    ) -> PyResult<Self> {
+        // Get the json out so we can reconstruct the tokenizer on the Rust side
+        let json = tokenizer.call_method0("to_str")?.extract::<PyBackedStr>()?;
+        let tokenizer =
+            Tokenizer::from_str(&json).map_err(|e| PyException::new_err(format!("{e}")))?;
+
+        Ok(Self {
+            splitter: CodeSplitterOptions::Huggingface(
+                CodeSplitter::new(
+                    Self::load_language(language),
+                    ChunkConfig::new(ChunkCapacity::try_from(capacity)?)
+                        .with_overlap(overlap)
+                        .map_err(PyChunkConfigError)?
+                        .with_sizer(tokenizer)
+                        .with_trim(trim),
+                )
+                .map_err(PyCodeSplitterError)?,
+            ),
+        })
+    }
+
+    /**
+    Instantiate a new markdown splitter from the given Hugging Face Tokenizer JSON string.
+
+    Args:
+        json (str): A valid JSON string representing a previously serialized
+            Hugging Face Tokenizer
+        capacity (int | (int, int)): The capacity of tokens in each chunk. If a
+            single int, then chunks will be filled up as much as possible, without going over
+            that number. If a tuple of two integers is provided, a chunk will be considered
+            "full" once it is within the two numbers (inclusive range). So it will only fill
+            up the chunk until the lower range is met.
+        overlap (int, optional): The maximum number of allowed tokens to overlap between chunks.
+            Defaults to 0.
+        trim (bool, optional): Specify whether chunks should have whitespace trimmed from the
+            beginning and end or not. If False, joining all chunks will return the original
+            string. Defaults to True.
+
+    Returns:
+        The new markdown splitter
+    */
+    #[staticmethod]
+    #[pyo3(signature = (language, json, capacity, overlap=0, trim=true))]
+    fn from_huggingface_tokenizer_str(
+        language: &Bound<'_, PyAny>,
+        json: &str,
+        capacity: PyChunkCapacity,
+        overlap: usize,
+        trim: bool,
+    ) -> PyResult<Self> {
+        let tokenizer = json
+            .parse()
+            .map_err(|e| PyException::new_err(format!("{e}")))?;
+
+        Ok(Self {
+            splitter: CodeSplitterOptions::Huggingface(
+                CodeSplitter::new(
+                    Self::load_language(language),
+                    ChunkConfig::new(ChunkCapacity::try_from(capacity)?)
+                        .with_overlap(overlap)
+                        .map_err(PyChunkConfigError)?
+                        .with_sizer(tokenizer)
+                        .with_trim(trim),
+                )
+                .map_err(PyCodeSplitterError)?,
+            ),
+        })
+    }
+
+    /**
+    Instantiate a new markdown splitter from the Hugging Face tokenizer file at the given path.
+
+    Args:
+        path (str): A path to a local JSON file representing a previously serialized
+            Hugging Face tokenizer.
+        capacity (int | (int, int)): The capacity of tokens in each chunk. If a
+            single int, then chunks will be filled up as much as possible, without going over
+            that number. If a tuple of two integers is provided, a chunk will be considered
+            "full" once it is within the two numbers (inclusive range). So it will only fill
+            up the chunk until the lower range is met.
+        overlap (int, optional): The maximum number of allowed tokens to overlap between chunks.
+            Defaults to 0.
+        trim (bool, optional): Specify whether chunks should have whitespace trimmed from the
+            beginning and end or not. If False, joining all chunks will return the original
+            string. Defaults to True.
+
+    Returns:
+        The new markdown splitter
+    */
+    #[staticmethod]
+    #[pyo3(signature = (language, path, capacity, overlap=0, trim=true))]
+    fn from_huggingface_tokenizer_file(
+        language: &Bound<'_, PyAny>,
+        path: &str,
+        capacity: PyChunkCapacity,
+        overlap: usize,
+        trim: bool,
+    ) -> PyResult<Self> {
+        let tokenizer =
+            Tokenizer::from_file(path).map_err(|e| PyException::new_err(format!("{e}")))?;
+        Ok(Self {
+            splitter: CodeSplitterOptions::Huggingface(
+                CodeSplitter::new(
+                    Self::load_language(language),
+                    ChunkConfig::new(ChunkCapacity::try_from(capacity)?)
+                        .with_overlap(overlap)
+                        .map_err(PyChunkConfigError)?
+                        .with_sizer(tokenizer)
+                        .with_trim(trim),
+                )
+                .map_err(PyCodeSplitterError)?,
+            ),
+        })
+    }
+
+    /**
+    Instantiate a new markdown splitter based on an OpenAI Tiktoken tokenizer.
+
+    Args:
+        model (str): The OpenAI model name you want to retrieve a tokenizer for.
+        capacity (int | (int, int)): The capacity of tokens in each chunk. If a
+            single int, then chunks will be filled up as much as possible, without going over
+            that number. If a tuple of two integers is provided, a chunk will be considered
+            "full" once it is within the two numbers (inclusive range). So it will only fill
+            up the chunk until the lower range is met.
+        overlap (int, optional): The maximum number of allowed tokens to overlap between chunks.
+            Defaults to 0.
+        trim (bool, optional): Specify whether chunks should have whitespace trimmed from the
+            beginning and end or not. If False, joining all chunks will return the original
+            string. Defaults to True.
+
+    Returns:
+        The new markdown splitter
+    */
+    #[staticmethod]
+    #[pyo3(signature = (language, model, capacity, overlap=0, trim=true))]
+    fn from_tiktoken_model(
+        language: &Bound<'_, PyAny>,
+        model: &str,
+        capacity: PyChunkCapacity,
+        overlap: usize,
+        trim: bool,
+    ) -> PyResult<Self> {
+        let tokenizer =
+            get_bpe_from_model(model).map_err(|e| PyException::new_err(format!("{e}")))?;
+
+        Ok(Self {
+            splitter: CodeSplitterOptions::Tiktoken(
+                CodeSplitter::new(
+                    Self::load_language(language),
+                    ChunkConfig::new(ChunkCapacity::try_from(capacity)?)
+                        .with_overlap(overlap)
+                        .map_err(PyChunkConfigError)?
+                        .with_sizer(tokenizer)
+                        .with_trim(trim),
+                )
+                .map_err(PyCodeSplitterError)?,
+            ),
+        })
+    }
+
+    /**
+    Instantiate a markdown text splitter based on a custom callback.
+
+    Args:
+        callback (Callable[[str], int]): A lambda or other function that can be called. It will be
+            provided a piece of text, and it should return an integer value for the size.
+        capacity (int | (int, int)): The capacity of each chunk. If a
+            single int, then chunks will be filled up as much as possible, without going over
+            that number. If a tuple of two integers is provided, a chunk will be considered
+            "full" once it is within the two numbers (inclusive range). So it will only fill
+            up the chunk until the lower range is met.
+        overlap (int, optional): The maximum allowed overlap to overlap between chunks.
+            Defaults to 0.
+        trim (bool, optional): Specify whether chunks should have whitespace trimmed from the
+            beginning and end or not. If False, joining all chunks will return the original
+            string. Defaults to True.
+
+    Returns:
+        The new markdown splitter
+    */
+    #[staticmethod]
+    #[pyo3(signature = (language, callback, capacity, overlap=0, trim=true))]
+    fn from_callback(
+        language: &Bound<'_, PyAny>,
+        callback: PyObject,
+        capacity: PyChunkCapacity,
+        overlap: usize,
+        trim: bool,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            splitter: CodeSplitterOptions::CustomCallback(
+                CodeSplitter::new(
+                    Self::load_language(language),
+                    ChunkConfig::new(ChunkCapacity::try_from(capacity)?)
+                        .with_overlap(overlap)
+                        .map_err(PyChunkConfigError)?
+                        .with_sizer(CustomCallback(callback))
+                        .with_trim(trim),
+                )
+                .map_err(PyCodeSplitterError)?,
+            ),
+        })
+    }
+
+    /**
+    Generate a list of chunks from a given text. Each chunk will be up to the `chunk_capacity`.
+
+    ## Method
+
+    To preserve as much semantic meaning within a chunk as possible, each chunk is composed of the largest semantic units that can fit in the next given chunk. For each splitter type, there is a defined set of semantic levels. Here is an example of the steps used:
+
+    1. Split the text by a increasing semantic levels.
+    2. Check the first item for each level and select the highest level whose first item still fits within the chunk size.
+    3. Merge as many of these neighboring sections of this level or above into a chunk to maximize chunk length. Boundaries of higher semantic levels are always included when merging, so that the chunk doesn't inadvertantly cross semantic boundaries.
+
+    The boundaries used to split the text if using the `chunks` method, in ascending order:
+
+    1. Characters
+    2. [Unicode Grapheme Cluster Boundaries](https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries)
+    3. [Unicode Word Boundaries](https://www.unicode.org/reports/tr29/#Word_Boundaries)
+    4. [Unicode Sentence Boundaries](https://www.unicode.org/reports/tr29/#Sentence_Boundaries)
+    5. Soft line breaks (single newline) which isn't necessarily a new element in Code.
+    6. Inline elements such as: text nodes, emphasis, strong, strikethrough, link, image, table cells, inline code, footnote references, task list markers, and inline html.
+    7. Block elements suce as: paragraphs, code blocks, footnote definitions, metadata. Also, a block quote or row/item within a table or list that can contain other "block" type elements, and a list or table that contains items.
+    8. Thematic breaks or horizontal rules.
+    9. Headings by level
+
+    Code is parsed according to the Commonmark spec, along with some optional features such as GitHub Flavored Code.
+
+    Args:
+        text (str): Text to split.
+
+    Returns:
+        A list of strings, one for each chunk. If `trim_chunks` was specified in the text
+        splitter, then each chunk will already be trimmed as well.
+    */
+    fn chunks<'text, 'splitter: 'text>(&'splitter self, text: &'text str) -> Vec<&'text str> {
+        self.splitter.chunks(text).collect()
+    }
+
+    /**
+    Generate a list of chunks from a given text, along with their character offsets in the original text. Each chunk will be up to the `chunk_capacity`.
+
+    See `chunks` for more information.
+
+    Args:
+        text (str): Text to split.
+
+    Returns:
+        A list of tuples, one for each chunk. The first item will be the character offset relative
+        to the original text. The second item is the chunk itself.
+        If `trim_chunks` was specified in the text splitter, then each chunk will already be
+        trimmed as well.
+    */
+    fn chunk_indices<'text, 'splitter: 'text>(
+        &'splitter self,
+        text: &'text str,
+    ) -> Vec<(usize, &'text str)> {
+        let mut offsets = ByteToCharOffsetTracker::new(text);
+        self.splitter
+            .chunk_indices(text)
+            .map(|c| offsets.map_byte_to_char(c))
+            .collect()
+    }
+}
+
 #[doc = include_str!("../README.md")]
 #[pymodule]
 fn semantic_text_splitter(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<PyTextSplitter>()?;
+    m.add_class::<PyCodeSplitter>()?;
     m.add_class::<PyMarkdownSplitter>()?;
+    m.add_class::<PyTextSplitter>()?;
     Ok(())
 }

--- a/bindings/python/tests/test_integration.py
+++ b/bindings/python/tests/test_integration.py
@@ -1,6 +1,6 @@
 import pytest
 from semantic_text_splitter import CodeSplitter, MarkdownSplitter, TextSplitter
-from tokenizers import Tokenizer
+from tokenizers import Tokenizer  # type: ignore
 from tree_sitter import Language
 import tree_sitter_python
 
@@ -278,3 +278,24 @@ def bar():
 def test_invalid_language() -> None:
     with pytest.raises(ValueError):
         splitter = CodeSplitter(tree_sitter_python.language() + 1, 40)
+
+
+def test_code_char_indices() -> None:
+    splitter = CodeSplitter(tree_sitter_python.language(), capacity=4)
+    text = "123\n456\n789"
+    assert splitter.chunk_indices(text) == [
+        (0, "123"),
+        (4, "456"),
+        (8, "789"),
+    ]
+
+
+def test_code_char_indices_with_multibyte_character() -> None:
+    splitter = CodeSplitter(tree_sitter_python.language(), 4)
+    text = "12ü\n12ü\n12ü"
+    assert len("12ü\n") == 4
+    assert splitter.chunk_indices(text=text) == [
+        (0, "12ü"),
+        (4, "12ü"),
+        (8, "12ü"),
+    ]

--- a/bindings/python/tests/test_integration.py
+++ b/bindings/python/tests/test_integration.py
@@ -1,6 +1,8 @@
 import pytest
-from semantic_text_splitter import MarkdownSplitter, TextSplitter
+from semantic_text_splitter import CodeSplitter, MarkdownSplitter, TextSplitter
 from tokenizers import Tokenizer
+from tree_sitter import Language
+import tree_sitter_python
 
 
 def test_chunks() -> None:
@@ -255,3 +257,24 @@ def test_markdown_char_indices_with_multibyte_character() -> None:
 def test_invalid_chunk_range() -> None:
     with pytest.raises(ValueError):
         splitter = TextSplitter((2, 1))
+
+
+def test_code_splitter() -> None:
+    splitter = CodeSplitter(tree_sitter_python.language(), 40)
+    text = """
+def foo():
+    return 42
+
+
+def bar():
+    return 7
+"""
+    assert splitter.chunks(text) == [
+        "def foo():\n    return 42",
+        "def bar():\n    return 7",
+    ]
+
+
+def test_invalid_language() -> None:
+    with pytest.raises(ValueError):
+        splitter = CodeSplitter(tree_sitter_python.language() + 1, 40)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,4 @@ pub use chunk_size::{
 pub use splitter::MarkdownSplitter;
 pub use splitter::TextSplitter;
 #[cfg(feature = "code")]
-pub use splitter::{CodeSplitterError, ExperimentalCodeSplitter};
+pub use splitter::{CodeSplitter, CodeSplitterError};

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -16,7 +16,7 @@ mod text;
 
 #[cfg(feature = "code")]
 #[allow(clippy::module_name_repetitions)]
-pub use code::{CodeSplitterError, ExperimentalCodeSplitter};
+pub use code::{CodeSplitter, CodeSplitterError};
 #[cfg(feature = "markdown")]
 #[allow(clippy::module_name_repetitions)]
 pub use markdown::MarkdownSplitter;

--- a/src/splitter/code.rs
+++ b/src/splitter/code.rs
@@ -9,7 +9,7 @@ use crate::{
     ChunkConfig, ChunkSizer,
 };
 
-/// Indicates there was an error with creating a `ExperimentalCodeSplitter`.
+/// Indicates there was an error with creating a `CodeSplitter`.
 /// The `Display` implementation will provide a human-readable error message to
 /// help debug the issue that caused the error.
 #[derive(Error, Debug)]
@@ -30,12 +30,9 @@ enum CodeSplitterErrorRepr {
 /// Source code splitter. Recursively splits chunks into the largest
 /// semantic units that fit within the chunk size. Also will attempt to merge
 /// neighboring chunks if they can fit within the given chunk size.
-///
-/// NOTE: This is still an experimental feature and output is not guaranteed
-/// to be stable, even between minor versions, until the Experimental name is removed.
 #[derive(Debug)]
 #[allow(clippy::module_name_repetitions)]
-pub struct ExperimentalCodeSplitter<Sizer>
+pub struct CodeSplitter<Sizer>
 where
     Sizer: ChunkSizer,
 {
@@ -45,17 +42,17 @@ where
     language: Language,
 }
 
-impl<Sizer> ExperimentalCodeSplitter<Sizer>
+impl<Sizer> CodeSplitter<Sizer>
 where
     Sizer: ChunkSizer,
 {
-    /// Creates a new [`ExperimentalCodeSplitter`].
+    /// Creates a new [`CodeSplitter`].
     ///
     /// ```
-    /// use text_splitter::ExperimentalCodeSplitter;
+    /// use text_splitter::CodeSplitter;
     ///
     /// // By default, the chunk sizer is based on characters.
-    /// let splitter = ExperimentalCodeSplitter::new(tree_sitter_rust::language(), 512).expect("Invalid language");
+    /// let splitter = CodeSplitter::new(tree_sitter_rust::language(), 512).expect("Invalid language");
     /// ```
     ///
     /// # Errors
@@ -99,9 +96,9 @@ where
     // Splitting doesn't occur below the character level, otherwise you could get partial bytes of a char, which may not be a valid unicode str.
     ///
     /// ```
-    /// use text_splitter::ExperimentalCodeSplitter;
+    /// use text_splitter::CodeSplitter;
     ///
-    /// let splitter = ExperimentalCodeSplitter::new(tree_sitter_rust::language(), 10).expect("Invalid language");
+    /// let splitter = CodeSplitter::new(tree_sitter_rust::language(), 10).expect("Invalid language");
     /// let text = "Some text\n\nfrom a\ndocument";
     /// let chunks = splitter.chunks(text).collect::<Vec<_>>();
     ///
@@ -117,12 +114,12 @@ where
     /// Returns an iterator over chunks of the text and their byte offsets.
     /// Each chunk will be up to the `chunk_capacity`.
     ///
-    /// See [`ExperimentalCodeSplitter::chunks`] for more information.
+    /// See [`CodeSplitter::chunks`] for more information.
     ///
     /// ```
-    /// use text_splitter::ExperimentalCodeSplitter;
+    /// use text_splitter::CodeSplitter;
     ///
-    /// let splitter = ExperimentalCodeSplitter::new(tree_sitter_rust::language(), 10).expect("Invalid language");
+    /// let splitter = CodeSplitter::new(tree_sitter_rust::language(), 10).expect("Invalid language");
     /// let text = "Some text\n\nfrom a\ndocument";
     /// let chunks = splitter.chunk_indices(text).collect::<Vec<_>>();
     ///
@@ -135,7 +132,7 @@ where
     }
 }
 
-impl<Sizer> Splitter<Sizer> for ExperimentalCodeSplitter<Sizer>
+impl<Sizer> Splitter<Sizer> for CodeSplitter<Sizer>
 where
     Sizer: ChunkSizer,
 {
@@ -234,7 +231,7 @@ mod tests {
 
     #[test]
     fn rust_splitter() {
-        let splitter = ExperimentalCodeSplitter::new(tree_sitter_rust::language(), 16).unwrap();
+        let splitter = CodeSplitter::new(tree_sitter_rust::language(), 16).unwrap();
         let text = "fn main() {\n    let x = 5;\n}";
         let chunks = splitter.chunks(text).collect::<Vec<_>>();
 
@@ -243,7 +240,7 @@ mod tests {
 
     #[test]
     fn rust_splitter_indices() {
-        let splitter = ExperimentalCodeSplitter::new(tree_sitter_rust::language(), 16).unwrap();
+        let splitter = CodeSplitter::new(tree_sitter_rust::language(), 16).unwrap();
         let text = "fn main() {\n    let x = 5;\n}";
         let chunks = splitter.chunk_indices(text).collect::<Vec<_>>();
 

--- a/tests/code.rs
+++ b/tests/code.rs
@@ -4,7 +4,7 @@ use fake::{Fake, Faker};
 use itertools::Itertools;
 use more_asserts::assert_le;
 #[cfg(feature = "code")]
-use text_splitter::{ChunkConfig, ExperimentalCodeSplitter};
+use text_splitter::{ChunkConfig, CodeSplitter};
 
 #[cfg(feature = "code")]
 #[test]
@@ -13,7 +13,7 @@ fn random_chunk_size() {
 
     for _ in 0..10 {
         let max_characters = Faker.fake();
-        let splitter = ExperimentalCodeSplitter::new(
+        let splitter = CodeSplitter::new(
             tree_sitter_rust::language(),
             ChunkConfig::new(max_characters).with_trim(false),
         )
@@ -34,7 +34,7 @@ fn random_chunk_indices_increase() {
 
     for _ in 0..10 {
         let max_characters = Faker.fake::<usize>();
-        let splitter = ExperimentalCodeSplitter::new(
+        let splitter = CodeSplitter::new(
             tree_sitter_rust::language(),
             ChunkConfig::new(max_characters),
         )
@@ -50,7 +50,7 @@ fn random_chunk_indices_increase() {
 fn can_handle_invalid_code() {
     let text = "No code here";
 
-    let splitter = ExperimentalCodeSplitter::new(
+    let splitter = CodeSplitter::new(
         tree_sitter_rust::language(),
         ChunkConfig::new(5).with_trim(false),
     )
@@ -69,8 +69,7 @@ fn fn2() {}
 fn fn3() {}
 fn fn4() {}";
 
-    let splitter =
-        ExperimentalCodeSplitter::new(tree_sitter_rust::language(), ChunkConfig::new(24)).unwrap();
+    let splitter = CodeSplitter::new(tree_sitter_rust::language(), ChunkConfig::new(24)).unwrap();
     let chunks = splitter.chunks(text).collect::<Vec<_>>();
 
     assert_eq!(
@@ -90,8 +89,7 @@ fn fn2() {
 fn fn3() {}
 fn fn4() {}";
 
-    let splitter =
-        ExperimentalCodeSplitter::new(tree_sitter_rust::language(), ChunkConfig::new(30)).unwrap();
+    let splitter = CodeSplitter::new(tree_sitter_rust::language(), ChunkConfig::new(30)).unwrap();
     let chunks = splitter.chunks(text).collect::<Vec<_>>();
 
     assert_eq!(
@@ -113,7 +111,7 @@ fn fn2() {}
 fn fn3() {}
 fn fn4() {}";
 
-    let splitter = ExperimentalCodeSplitter::new(
+    let splitter = CodeSplitter::new(
         tree_sitter_rust::language(),
         ChunkConfig::new(24).with_overlap(12).unwrap(),
     )

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -7,7 +7,7 @@ use rayon::prelude::*;
 use rust_tokenizers::tokenizer::BertTokenizer;
 use strum::{Display, EnumIter, IntoEnumIterator};
 #[cfg(feature = "code")]
-use text_splitter::ExperimentalCodeSplitter;
+use text_splitter::CodeSplitter;
 #[cfg(feature = "markdown")]
 use text_splitter::MarkdownSplitter;
 use text_splitter::{Characters, ChunkCapacity, ChunkConfig, ChunkSize, ChunkSizer, TextSplitter};
@@ -379,8 +379,7 @@ fn code_trim_false() {
                 .with_sizer(sizer)
                 .with_trim(false);
             let capacity = *config.capacity();
-            let splitter =
-                ExperimentalCodeSplitter::new(tree_sitter_rust::language(), config).unwrap();
+            let splitter = CodeSplitter::new(tree_sitter_rust::language(), config).unwrap();
             let chunks = splitter.chunks(&text).collect::<Vec<_>>();
 
             assert_eq!(chunks.join(""), text);
@@ -408,8 +407,7 @@ fn code_trim() {
             let sizer = Characters;
             let config = ChunkConfig::new(chunk_size).with_sizer(sizer);
             let capacity = *config.capacity();
-            let splitter =
-                ExperimentalCodeSplitter::new(tree_sitter_rust::language(), config).unwrap();
+            let splitter = CodeSplitter::new(tree_sitter_rust::language(), config).unwrap();
             let chunks = splitter.chunks(&text).collect::<Vec<_>>();
 
             for chunk in &chunks {
@@ -440,8 +438,7 @@ fn code_overlap_trim_false() {
                 .unwrap()
                 .with_trim(false);
             let capacity = *config.capacity();
-            let splitter =
-                ExperimentalCodeSplitter::new(tree_sitter_rust::language(), config).unwrap();
+            let splitter = CodeSplitter::new(tree_sitter_rust::language(), config).unwrap();
             let chunks = splitter.chunks(&text).collect::<Vec<_>>();
 
             for chunk in &chunks {
@@ -471,8 +468,7 @@ fn code_overlap_trim() {
                 .with_overlap(overlap)
                 .unwrap();
             let capacity = *config.capacity();
-            let splitter =
-                ExperimentalCodeSplitter::new(tree_sitter_rust::language(), config).unwrap();
+            let splitter = CodeSplitter::new(tree_sitter_rust::language(), config).unwrap();
             let chunks = splitter.chunks(&text).collect::<Vec<_>>();
 
             for chunk in &chunks {


### PR DESCRIPTION
Marks the code splitter ready and also sets up the Python bindings so it can be called from there.

It also supports passing tree-sitter grammars from Python, since they are both using the same C bindings under the hood anyway.