### PR TITLE
Optimization for SemanticSplitRange searching

### DIFF
--- a/src/trim.rs
+++ b/src/trim.rs
@@ -56,6 +56,7 @@ mod tests {
         assert_eq!(chunk, "hello world");
     }
 
+    #[cfg(any(feature = "markdown", feature = "code"))]
     #[test]
     fn trim_indentation_fallback() {
         let chunk = "  hello world  ";
@@ -64,6 +65,7 @@ mod tests {
         assert_eq!(chunk, "hello world");
     }
 
+    #[cfg(any(feature = "markdown", feature = "code"))]
     #[test]
     fn trim_indentation_preserved() {
         let chunk = "\n  hello\n  world  ";

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -306,6 +306,7 @@ fn markdown_trim() {
     });
 }
 
+#[cfg(feature = "markdown")]
 #[test]
 fn markdown_overlap_trim_false() {
     insta::glob!("inputs/markdown/*.md", |path| {
@@ -337,6 +338,7 @@ fn markdown_overlap_trim_false() {
     });
 }
 
+#[cfg(feature = "markdown")]
 #[test]
 fn markdown_overlap_trim() {
     insta::glob!("inputs/markdown/*.md", |path| {
@@ -424,6 +426,7 @@ fn code_trim() {
     });
 }
 
+#[cfg(feature = "code")]
 #[test]
 fn code_overlap_trim_false() {
     insta::glob!("inputs/code/*.txt", |path| {
@@ -455,6 +458,7 @@ fn code_overlap_trim_false() {
     });
 }
 
+#[cfg(feature = "code")]
 #[test]
 fn code_overlap_trim() {
     insta::glob!("inputs/code/*.txt", |path| {


### PR DESCRIPTION
Leverages the fact that these ranges are guaranteed to be sorted now. Rather than doing a retain, which likely moves items in the vec and also has to iterate over all values, instead there is a cursor to extract the desired slice, and we can move the cursor to the first item that would still be in the range we desire.