### PR TITLE
0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.15.0
+
+### What's New
+
+- Support version `0.20.0` of the `tokenizers` crate.
+
+#### Python
+
+- No longer cause a segmentation fault when using the wrong type for tree-sitter languages. Fixes [#265](https://github.com/benbrandt/text-splitter/issues/265)
+
 ## v0.14.1
 
 ### What's New

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "semantic-text-splitter"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "pyo3",
  "text-splitter",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "text-splitter"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "ahash",
  "auto_enums",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
+checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
 dependencies = [
  "jobserver",
  "libc",
@@ -261,18 +261,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.14"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c937d4061031a6d0c8da4b9a4f98a172fc2976dfb1c19213a9cf7d0d3c837e36"
+checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.14"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85379ba512b21a328adf887e85f7742d12e96eb31f3ef077df4ffc26b506ffed"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -1586,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -1754,15 +1754,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.5",
+ "rustls-webpki 0.102.6",
  "subtle",
  "zeroize",
 ]
@@ -1794,9 +1794,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.5"
+version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2414,7 +2414,7 @@ dependencies = [
  "log",
  "native-tls",
  "once_cell",
- "rustls 0.23.10",
+ "rustls 0.23.12",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2583,7 +2583,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["bindings/*"]
 
 [workspace.package]
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Ben Brandt <benjamin.j.brandt@gmail.com>"]
 edition = "2021"
 description = "Split text into semantic chunks, up to a desired chunk size. Supports calculating length by characters and tokens, and is callable from Rust and Python."

--- a/README.md
+++ b/README.md
@@ -192,18 +192,18 @@ There are lots of methods of determining sentence breaks, all to varying degrees
 
 ### Document Format Support
 
-| Feature    | Description                                                                                   |
-| ---------- | --------------------------------------------------------------------------------------------- |
+| Feature    | Description                                                                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `code`     | Enables the `CodeSplitter` struct for parsing code documents via [tree-sitter parsers](https://tree-sitter.github.io/tree-sitter/#parsers). |
-| `markdown` | Enables the `MarkdownSplitter` struct for parsing Markdown documents via the `CommonMark` spec. |
+| `markdown` | Enables the `MarkdownSplitter` struct for parsing Markdown documents via the `CommonMark` spec.                                             |
 
 ### Tokenizer Support
 
 | Dependency Feature | Version Supported | Description                                                                                                                                                                    |
 | ------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `rust_tokenizers`  | `^8.0.0`           | Enables `(Text/Markdown)Splitter::new` to take any of the provided tokenizers as an argument.                                                                                  |
-| `tiktoken-rs`      | `^0.5.0`           | Enables `(Text/Markdown)Splitter::new` to take `tiktoken_rs::CoreBPE` as an argument. This is useful for splitting text for `OpenAI` models.                                     |
-| `tokenizers`       | `^0.19.0`          | Enables `(Text/Markdown)Splitter::new` to take `tokenizers::Tokenizer` as an argument. This is useful for splitting text models that have a Hugging Face-compatible tokenizer. |
+| `rust_tokenizers`  | `^8.0.0`          | Enables `(Text/Markdown)Splitter::new` to take any of the provided tokenizers as an argument.                                                                                  |
+| `tiktoken-rs`      | `^0.5.0`          | Enables `(Text/Markdown)Splitter::new` to take `tiktoken_rs::CoreBPE` as an argument. This is useful for splitting text for `OpenAI` models.                                   |
+| `tokenizers`       | `^0.20.0`         | Enables `(Text/Markdown)Splitter::new` to take `tokenizers::Tokenizer` as an argument. This is useful for splitting text models that have a Hugging Face-compatible tokenizer. |
 
 ## Inspiration
 

--- a/bindings/python/tests/test_integration.py
+++ b/bindings/python/tests/test_integration.py
@@ -1,7 +1,6 @@
 import pytest
 from semantic_text_splitter import CodeSplitter, MarkdownSplitter, TextSplitter
 from tokenizers import Tokenizer  # type: ignore
-from tree_sitter import Language
 import tree_sitter_python
 
 
@@ -256,7 +255,7 @@ def test_markdown_char_indices_with_multibyte_character() -> None:
 
 def test_invalid_chunk_range() -> None:
     with pytest.raises(ValueError):
-        splitter = TextSplitter((2, 1))
+        TextSplitter((2, 1))
 
 
 def test_code_splitter() -> None:
@@ -277,7 +276,12 @@ def bar():
 
 def test_invalid_language() -> None:
     with pytest.raises(ValueError):
-        splitter = CodeSplitter(tree_sitter_python.language() + 1, 40)
+        CodeSplitter(tree_sitter_python.language() + 1, 40)
+
+
+def test_invalid_language_type() -> None:
+    with pytest.raises(TypeError):
+        CodeSplitter(tree_sitter_python.language, 40)  # type: ignore
 
 
 def test_code_char_indices() -> None:


### PR DESCRIPTION
- **fix: avoid segmentation fault if wrong type passed in for tree-sitter language**
- **chore: prep 0.15.0 release**
