### PR TITLE
Cleanup and simplification

### DIFF
--- a/src/chunk_size.rs
+++ b/src/chunk_size.rs
@@ -420,8 +420,8 @@ where
 
     /// Clear the cached values. Once we've moved the cursor,
     /// we don't need to keep the old values around.
-    pub fn clear_cache(&mut self, offset: usize) {
-        self.size_cache.retain(|k, _| k.start >= offset);
+    pub fn clear_cache(&mut self) {
+        self.size_cache.clear();
     }
 }
 
@@ -617,7 +617,7 @@ mod tests {
         let text = "1234567890";
         for _ in 0..10 {
             memoized_sizer.chunk_size(0, text);
-            memoized_sizer.clear_cache(text.len());
+            memoized_sizer.clear_cache();
         }
 
         assert_eq!(

--- a/src/chunk_size.rs
+++ b/src/chunk_size.rs
@@ -357,17 +357,12 @@ where
 
     /// Determine the size of a given chunk to use for validation,
     /// returning a cached value if it exists, and storing the result if not.
-    fn chunk_size(&mut self, offset: usize, chunk: &str) -> usize {
+    pub fn chunk_size(&mut self, offset: usize, chunk: &str) -> usize {
+        let (offset, chunk) = self.trim_chunk(offset, chunk);
         *self
             .size_cache
             .entry(offset..(offset + chunk.len()))
             .or_insert_with(|| self.sizer.size(chunk))
-    }
-
-    /// Check if the chunk is within the capacity. Chunk should be trimmed if necessary beforehand.
-    pub fn check_capacity(&mut self, offset: usize, chunk: &str) -> usize {
-        let (offset, chunk) = self.trim_chunk(offset, chunk);
-        self.chunk_size(offset, chunk)
     }
 
     /// If trim chunks is on, trim the str and adjust the offset
@@ -399,7 +394,7 @@ where
             // Skip tokenizing levels that we know are too small anyway.
             let len = str.len();
             if len > capacity.max {
-                let chunk_size = self.check_capacity(offset, str);
+                let chunk_size = self.chunk_size(offset, str);
                 let fits = capacity.fits(chunk_size);
                 // If this no longer fits, we use the level we are at.
                 if fits.is_gt() {

--- a/src/chunk_size.rs
+++ b/src/chunk_size.rs
@@ -59,8 +59,8 @@ enum ChunkCapacityErrorRepr {
 /// higher semantic level when determining the chunk.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct ChunkCapacity {
-    desired: usize,
-    max: usize,
+    pub(crate) desired: usize,
+    pub(crate) max: usize,
 }
 
 impl ChunkCapacity {
@@ -213,13 +213,13 @@ where
     Sizer: ChunkSizer,
 {
     /// The chunk capacity to use for filling chunks
-    capacity: ChunkCapacity,
+    pub(crate) capacity: ChunkCapacity,
     /// The amount of overlap between chunks. Defaults to 0.
-    overlap: usize,
+    pub(crate) overlap: usize,
     /// The chunk sizer to use for determining the size of each chunk
-    sizer: Sizer,
+    pub(crate) sizer: Sizer,
     /// Whether whitespace will be trimmed from the beginning and end of each chunk
-    trim: bool,
+    pub(crate) trim: bool,
 }
 
 impl ChunkConfig<Characters> {

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -314,8 +314,9 @@ where
             let text_end = offset + str.len();
             let chunk = self.text.get(start..text_end)?;
             let chunk_size = self.chunk_sizer.check_capacity(start, chunk, false);
+            let fits = self.chunk_config.capacity().fits(chunk_size.size());
 
-            match chunk_size.fits() {
+            match fits {
                 Ordering::Less => {
                     // We got further than the last one, so update end
                     if text_end > end {
@@ -344,7 +345,7 @@ where
             };
 
             // Adjust search area
-            if chunk_size.fits().is_lt() {
+            if fits.is_lt() {
                 low = mid + 1;
             } else if mid > 0 {
                 high = mid - 1;
@@ -406,14 +407,15 @@ where
                 self.text.get(offset..end).expect("Invalid range"),
                 true,
             );
+            let fits = self.chunk_config.capacity().fits(chunk_size.size());
 
             // We got further than the last one, so update start
-            if chunk_size.fits().is_le() && offset < start && offset > self.cursor {
+            if fits.is_le() && offset < start && offset > self.cursor {
                 start = offset;
             }
 
             // Adjust search area
-            if chunk_size.fits().is_lt() && mid > 0 {
+            if fits.is_lt() && mid > 0 {
                 high = mid - 1;
             } else {
                 low = mid + 1;
@@ -511,8 +513,8 @@ where
                     self.text.get(self.cursor..text_end).expect("Invalid range"),
                     false,
                 );
+                let fits = self.chunk_config.capacity().fits(chunk_size.size());
 
-                let fits = chunk_size.fits();
                 if fits.is_le() {
                     let final_offset = offset + str.len() - self.cursor;
                     let size = chunk_size.size().max(1);

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -515,7 +515,7 @@ where
             // Check if the last item fits
             if let Some(&(offset, str)) = self.next_sections.last() {
                 let text_end = offset + str.len();
-                if text_end < target_offset {
+                if (text_end - self.cursor) < target_offset {
                     break;
                 }
                 let chunk_size = self.chunk_sizer.chunk_size(

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -277,13 +277,13 @@ where
     /// Returns final byte offset and str.
     /// Will return `None` if given an invalid range.
     fn next_chunk(&mut self) -> Option<(usize, &'text str)> {
-        // Reset caches so we can reuse the memory allocation
-        self.chunk_sizer.clear_cache(self.cursor);
         self.semantic_split.update_cursor(self.cursor);
         let low = self.update_next_sections();
 
         let (start, end) = self.binary_search_next_chunk(low)?;
 
+        // Reset caches so we can reuse the memory allocation
+        self.chunk_sizer.clear_cache();
         // Optionally move cursor back if overlap is desired
         self.update_cursor(end);
 

--- a/src/trim.rs
+++ b/src/trim.rs
@@ -17,6 +17,8 @@ pub enum Trim {
     /// the meaning of the text.
     #[cfg(any(feature = "markdown", feature = "code"))]
     PreserveIndentation,
+    /// Apply no trimming
+    None,
 }
 
 #[cfg(any(feature = "markdown", feature = "code"))]
@@ -40,6 +42,7 @@ impl Trim {
                     Self::All.trim(offset, chunk)
                 }
             }
+            Self::None => (offset, chunk),
         }
     }
 }


### PR DESCRIPTION
- **refactor: don't cache fits**
- **refactor: remove ChunkSize abstraction and unify caches**
- **fix: cache clearing issue with overlap**
- **refactor: Memoized sizer no longer needs the entire chunk config**
- **refactor: clean up chunk size method naming**
- **refactor: pull trim logic out of sizer**
- **refactor: flatten and transform chunk config**
- **fix: break condition**
