### PR TITLE
Ensure tokenizer sizers with truncation parameters count their overflow encodings

### DIFF
--- a/src/chunk_size/huggingface.rs
+++ b/src/chunk_size/huggingface.rs
@@ -5,7 +5,7 @@ use crate::ChunkSizer;
 /// Compute the number of tokens that exist within an entire [`Encoding`] object.
 ///
 /// Take into account [`Encoding::get_overflowing`] for cases where the [`Tokenizer`] producing the [`Encoding`] has truncation parameters set.
-pub(crate) fn num_tokens_with_overflow(encoding: &Encoding, pad_id: Option<u32>) -> usize {
+fn num_tokens_with_overflow(encoding: &Encoding, pad_id: Option<u32>) -> usize {
     let base = encoding
         .get_ids()
         .iter()

--- a/src/chunk_size/huggingface.rs
+++ b/src/chunk_size/huggingface.rs
@@ -1,6 +1,28 @@
-use tokenizers::Tokenizer;
+use tokenizers::{Encoding, Tokenizer};
 
 use crate::ChunkSizer;
+
+/// Compute the number of tokens that exist within an entire [`Encoding`] object.
+///
+/// Take into account [`Encoding::get_overflowing`] for cases where the [`Tokenizer`] producing the [`Encoding`] has truncation parameters set.
+pub(crate) fn num_tokens_with_overflow(encoding: &Encoding, pad_id: Option<u32>) -> usize {
+    let base = encoding
+        .get_ids()
+        .iter()
+        // Skip padding tokens at beginning and end so they don't count towards the chunk size
+        .skip_while(|&id| pad_id.map_or(false, |pad_id| id == &pad_id))
+        .take_while(|&id| pad_id.map_or(true, |pad_id| id != &pad_id))
+        .count();
+
+    // If the [`Tokenizer`] has truncation, need to check overflow encodings to determine overall size.
+    let overflow: usize = encoding
+        .get_overflowing()
+        .iter()
+        .map(|enc| num_tokens_with_overflow(enc, pad_id))
+        .sum();
+
+    base + overflow
+}
 
 impl ChunkSizer for &Tokenizer {
     /// Returns the number of tokens in a given text after tokenization.
@@ -15,14 +37,7 @@ impl ChunkSizer for &Tokenizer {
             .expect("Unable to tokenize the following string {chunk}");
 
         let pad_id = self.get_padding().map(|params| params.pad_id);
-
-        encoding
-            .get_ids()
-            .iter()
-            // Skip padding tokens at beginning and end so they don't count towards the chunk size
-            .skip_while(|&id| pad_id.map_or(false, |pad_id| id == &pad_id))
-            .take_while(|&id| pad_id.map_or(true, |pad_id| id != &pad_id))
-            .count()
+        num_tokens_with_overflow(&encoding, pad_id)
     }
 }
 
@@ -63,5 +78,17 @@ mod tests {
         let tokenizer = Tokenizer::from_pretrained("thenlper/gte-small", None).unwrap();
         let size = tokenizer.size("An apple a");
         assert_eq!(size, 3);
+    }
+
+    #[test]
+    fn handle_truncation() {
+        let tokenizer = Tokenizer::from_pretrained("sentence-transformers/all-MiniLM-L6-v2", None)
+            .expect("Could not load tokenizer 'sentence-transformers/all-MiniLM-L6-v2'");
+
+        // Need to ensure chunk is large enough to cause Encoding overflows.
+        assert_eq!(
+            tokenizer.size("An apple a day keeps the doctor away.".repeat(100).as_str()),
+            900
+        );
     }
 }


### PR DESCRIPTION
## Bug fix
When determining the size of a chunk that would exceed a tokenizer's [TruncationParams](https://github.com/huggingface/tokenizers/blob/main/tokenizers/src/tokenizer/mod.rs#L524) (when set, generally via a [tokenizer.json](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/blob/main/tokenizer.json)'s  `truncation` key), it would ignore the [Encoding::get_overflowing](https://github.com/huggingface/tokenizers/blob/main/tokenizers/src/tokenizer/encoding.rs#L27). 

This PR fixes this issue by recursively computing the size of these overflows too. 


--- 
Note: Not all Tokenizers have truncation, hence passing tests for [Tokenizer::from_pretrained("bert-base-cased", None)](https://huggingface.co/google-bert/bert-base-cased/blob/main/tokenizer.json) ([link](https://github.com/benbrandt/text-splitter/blob/main/src/chunk_size/huggingface.rs#L47)). 
 - [thenlper/gte-small](https://huggingface.co/thenlper/gte-small) has truncation parameters, but they are too large to be causing issues in unit testing. 