### PR TITLE
style: Replace allow attributes with expect attributes

### DIFF
--- a/benches/chunk_size.rs
+++ b/benches/chunk_size.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)]
+#![expect(missing_docs)]
 
 use std::{fs, sync::LazyLock};
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,8 +1,5 @@
 //! Python Bindings for text-splitter crate
 
-// pyo3 uses these
-#![allow(elided_lifetimes_in_paths, unsafe_op_in_unsafe_fn)]
-
 use std::str::FromStr;
 
 use pyo3::{

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -15,12 +15,9 @@ mod markdown;
 mod text;
 
 #[cfg(feature = "code")]
-#[allow(clippy::module_name_repetitions)]
 pub use code::{CodeSplitter, CodeSplitterError};
 #[cfg(feature = "markdown")]
-#[allow(clippy::module_name_repetitions)]
 pub use markdown::MarkdownSplitter;
-#[allow(clippy::module_name_repetitions)]
 pub use text::TextSplitter;
 
 /// Shared interface for splitters that can generate chunks of text based on the
@@ -454,7 +451,7 @@ where
     /// Find the ideal next sections, breaking it up until we find the largest chunk.
     /// Increasing length of chunk until we find biggest size to minimize validation time
     /// on huge chunks
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn update_next_sections(&mut self) -> usize {
         // First thing, clear out the list, but reuse the allocated memory
         self.next_sections.clear();

--- a/src/splitter/code.rs
+++ b/src/splitter/code.rs
@@ -16,7 +16,6 @@ use super::ChunkCharIndex;
 /// help debug the issue that caused the error.
 #[derive(Error, Debug)]
 #[error(transparent)]
-#[allow(clippy::module_name_repetitions)]
 pub struct CodeSplitterError(#[from] CodeSplitterErrorRepr);
 
 /// Private error and free to change across minor version of the crate.
@@ -33,7 +32,6 @@ enum CodeSplitterErrorRepr {
 /// semantic units that fit within the chunk size. Also will attempt to merge
 /// neighboring chunks if they can fit within the given chunk size.
 #[derive(Debug)]
-#[allow(clippy::module_name_repetitions)]
 pub struct CodeSplitter<Sizer>
 where
     Sizer: ChunkSizer,

--- a/src/splitter/fallback.rs
+++ b/src/splitter/fallback.rs
@@ -14,7 +14,6 @@ static SENTENCE_SEGMENTER: LazyLock<SentenceSegmenter> = LazyLock::new(SentenceS
 /// be small enough to fit into the chunk size. In order to make sure we can
 /// still move the cursor forward, we fallback to unicode segmentation.
 #[derive(Clone, Copy, Debug, EnumIter, Eq, PartialEq, Ord, PartialOrd)]
-#[allow(clippy::module_name_repetitions)]
 pub enum FallbackLevel {
     /// Split by individual chars. May be larger than a single byte,
     /// but we don't go lower so we always have valid UTF str's.

--- a/src/splitter/markdown.rs
+++ b/src/splitter/markdown.rs
@@ -23,7 +23,6 @@ use super::ChunkCharIndex;
 /// attempt to merge neighboring chunks if they can fit within the
 /// given chunk size.
 #[derive(Debug)]
-#[allow(clippy::module_name_repetitions)]
 pub struct MarkdownSplitter<Sizer>
 where
     Sizer: ChunkSizer,

--- a/src/splitter/text.rs
+++ b/src/splitter/text.rs
@@ -19,7 +19,6 @@ use super::{fallback::GRAPHEME_SEGMENTER, ChunkCharIndex};
 /// semantic units that fit within the chunk size. Also will attempt to merge
 /// neighboring chunks if they can fit within the given chunk size.
 #[derive(Debug)]
-#[allow(clippy::module_name_repetitions)]
 pub struct TextSplitter<Sizer>
 where
     Sizer: ChunkSizer,
@@ -143,7 +142,7 @@ where
     }
 
     fn parse(&self, text: &str) -> Vec<(Self::Level, Range<usize>)> {
-        #[allow(clippy::range_plus_one)]
+        #[expect(clippy::range_plus_one)]
         memchr2_iter(b'\n', b'\r', text.as_bytes())
             .map(|i| i..i + 1)
             .coalesce(|a, b| {

--- a/src/trim.rs
+++ b/src/trim.rs
@@ -4,7 +4,6 @@ Different trimming behaviors for different splitter types.
 
 /// Out-of-the-box trim options.
 /// If you need a custom trim behavior, you can implement the `Trim` trait.
-#[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Copy, Debug)]
 pub enum Trim {
     /// Will remove all leading and trailing whitespaces.


### PR DESCRIPTION
The change replaces #[allow] attributes with #[expect] across the codebase where
warnings are explicitly acknowledged and expected to remain.
