### PR TITLE
Added support for bpe-tokenizer

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:crates.io)",
+      "WebFetch(domain:github.com)",
+      "Bash(cargo build:*)",
+      "WebFetch(domain:docs.rs)",
+      "Bash(cargo test:*)",
+      "Bash(cargo run:*)"
+    ]
+  },
+  "enableAllProjectMcpServers": false
+}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,5 @@
+elixir 1.18.2-otp-27
+erlang 27.2.4
+nodejs 23.11.0
+rust 1.88.0
+pandoc 3.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aneubeck-daachorse"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a902604543851c9ccc59d6252eb77502a9e01d6bf7205dd2ab4b543bd22cbda3"
+
+[[package]]
 name = "anstyle"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +99,35 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bpe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f0f0ef446ddbb042aac62a2da0b680e116b6cb2b1f79c20eda2a9107611408"
+dependencies = [
+ "aneubeck-daachorse",
+ "base64 0.22.1",
+ "fnv",
+ "itertools",
+ "serde",
+]
+
+[[package]]
+name = "bpe-openai"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25deec0a72cf5d8b66a6e487c5ee9757b0639f3e16d687f6c6dea834812000c"
+dependencies = [
+ "base64 0.22.1",
+ "bpe",
+ "either",
+ "flate2",
+ "regex-automata",
+ "rmp-serde",
+ "serde",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "bstr"
@@ -914,6 +949,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1252,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1530,7 @@ version = "0.27.0"
 dependencies = [
  "ahash",
  "auto_enums",
+ "bpe-openai",
  "dirs",
  "divan",
  "either",
@@ -1528,6 +1595,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
@@ -1604,6 +1686,15 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ strum = { version = "0.27", features = ["derive"] }
 thiserror = "2.0.12"
 tiktoken-rs = { version = "0.7", optional = true }
 tokenizers = { version = "0.21", default-features = false, optional = true }
+bpe-openai = { version = "0.3", optional = true }
 tree-sitter = { version = "0.25", optional = true }
 
 [dev-dependencies]
@@ -96,6 +97,7 @@ code = ["dep:tree-sitter"]
 markdown = ["dep:pulldown-cmark"]
 tiktoken-rs = ["dep:tiktoken-rs"]
 tokenizers = ["dep:tokenizers", "tokenizers/onig"]
+bpe = ["dep:bpe-openai"]
 
 [lints]
 workspace = true

--- a/examples/bpe_example.rs
+++ b/examples/bpe_example.rs
@@ -1,0 +1,51 @@
+/// Example demonstrating BPE tokenization support
+/// Run with: cargo run --example bpe_example --features bpe
+#[cfg(feature = "bpe")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use bpe_openai::{cl100k_base, o200k_base};
+    use text_splitter::{ChunkConfig, TextSplitter};
+
+    // Create cl100k tokenizer (used by GPT-3.5 and GPT-4)
+    let cl100k_tokenizer = cl100k_base();
+    println!("cl100k tokenizer loaded");
+
+    // Create o200k tokenizer (used by GPT-4o)
+    let o200k_tokenizer = o200k_base();
+    println!("o200k tokenizer loaded");
+
+    let text = "This is a sample text that we want to split using BPE tokenization. \
+                The BPE tokenizer will count tokens efficiently and allow us to create \
+                chunks based on token count rather than character count.";
+
+    // Example with cl100k tokenizer
+    let chunk_config = ChunkConfig::new(50).with_sizer(cl100k_tokenizer);
+    let splitter = TextSplitter::new(chunk_config);
+    let chunks = splitter.chunks(text);
+
+    println!("\nUsing cl100k tokenizer (chunks limited to 50 tokens):");
+    for (i, chunk) in chunks.enumerate() {
+        let token_count = cl100k_base().count(chunk);
+        println!("Chunk {}: {} tokens\n{}", i + 1, token_count, chunk);
+        println!("---");
+    }
+
+    // Example with o200k tokenizer
+    let chunk_config = ChunkConfig::new(30).with_sizer(o200k_tokenizer);
+    let splitter = TextSplitter::new(chunk_config);
+    let chunks = splitter.chunks(text);
+
+    println!("\nUsing o200k tokenizer (chunks limited to 30 tokens):");
+    for (i, chunk) in chunks.enumerate() {
+        let token_count = o200k_base().count(chunk);
+        println!("Chunk {}: {} tokens\n{}", i + 1, token_count, chunk);
+        println!("---");
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "bpe"))]
+fn main() {
+    println!("This example requires the 'bpe' feature to be enabled.");
+    println!("Run with: cargo run --example bpe_example --features bpe");
+}

--- a/src/chunk_size.rs
+++ b/src/chunk_size.rs
@@ -17,6 +17,8 @@ mod characters;
 mod huggingface;
 #[cfg(feature = "tiktoken-rs")]
 mod tiktoken;
+#[cfg(feature = "bpe")]
+mod bpe;
 
 use crate::trim::Trim;
 pub use characters::Characters;

--- a/src/chunk_size/bpe.rs
+++ b/src/chunk_size/bpe.rs
@@ -1,0 +1,24 @@
+use bpe_openai::Tokenizer;
+
+use crate::ChunkSizer;
+
+impl ChunkSizer for Tokenizer {
+    /// Returns the number of tokens in a given text after tokenization.
+    fn size(&self, chunk: &str) -> usize {
+        self.count(chunk)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bpe_openai::cl100k_base;
+
+    #[test]
+    fn returns_correct_token_count() {
+        let tokenizer = cl100k_base();
+        let size = tokenizer.size("An apple a");
+        assert_eq!(size, 3);
+    }
+}


### PR DESCRIPTION
There's now a faster BPE tokenizer than is used by the main `text-splitter` library:
https://github.com/github/rust-gems/

This PR adds the ability to use this tokenizer instead of tiktoken-rs for text splitting.